### PR TITLE
Make alpha optional when parsing a Color from an input stream

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Ignition Math 6.x.x
 
+1. Make alpha optional when parsing a Color from an input stream.
+    * [Pull request 106](https://github.com/ignitionrobotics/ign-math/pull/106)
+
 1. Added a Gauss-Markov Process class.
     * [BitBucket pull request 342](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-math/pull-requests/342)
 

--- a/include/ignition/math/Color.hh
+++ b/include/ignition/math/Color.hh
@@ -247,13 +247,27 @@ namespace ignition
       }
 
       /// \brief Stream insertion operator
-      /// \param[in] _in the input stream
+      /// \param[in] _in the input stream. If the input stream does not include
+      /// an alpha value, a default alpha value of 1.0 will be used.
       /// \param[in] _pt
       public: friend std::istream &operator>> (std::istream &_in, Color &_pt)
       {
         // Skip white spaces
         _in.setf(std::ios_base::skipws);
-        _in >> _pt.r >> _pt.g >> _pt.b >> _pt.a;
+        _in >> _pt.r >> _pt.g >> _pt.b;
+        // Since alpha is optional, check if it's there before parsing
+        while (!_in.eof() && std::isspace(_in.peek()))
+        {
+          _in.get();
+        }
+        if (!_in.eof())
+        {
+          _in >> _pt.a;
+        }
+        else
+        {
+          _pt.a = 1.0;
+        }
         return _in;
       }
 

--- a/src/Color_TEST.cc
+++ b/src/Color_TEST.cc
@@ -366,7 +366,7 @@ TEST(Color, OperatorStreamInWithoutAlpha)
   }
 
   {
-    math::Color test(0.5, 0.6, 0.7, 0.8);
+    math::Color test(0.5f, 0.6f, 0.7f, 0.8f);
     std::stringstream ss("0.1  0.2 \t0.3   \t");
     ss.exceptions(std::stringstream::failbit);
     EXPECT_NO_THROW(ss >> test);

--- a/src/Color_TEST.cc
+++ b/src/Color_TEST.cc
@@ -337,6 +337,44 @@ TEST(Color, OperatorStreamOut)
 }
 
 /////////////////////////////////////////////////
+TEST(Color, OperatorStreamIn)
+{
+  math::Color c(0.1f, 0.2f, 0.3f, 0.5f);
+  math::Color test;
+  std::stringstream ss("0.1 0.2 0.3 0.5");
+  ss >> test;
+  EXPECT_EQ(c, test);
+}
+
+/////////////////////////////////////////////////
+TEST(Color, OperatorStreamInWithoutAlpha)
+{
+  math::Color c(0.1f, 0.2f, 0.3f, 1.0f);
+  {
+    math::Color test;
+    std::stringstream ss("0.1 0.2 0.3");
+    ss.exceptions(std::stringstream::failbit);
+    EXPECT_NO_THROW(ss >> test);
+    EXPECT_EQ(c, test);
+  }
+  {
+    math::Color test;
+    std::stringstream ss("0.1  0.2 \t0.3   \t");
+    ss.exceptions(std::stringstream::failbit);
+    EXPECT_NO_THROW(ss >> test);
+    EXPECT_EQ(c, test);
+  }
+
+  {
+    math::Color test(0.5, 0.6, 0.7, 0.8);
+    std::stringstream ss("0.1  0.2 \t0.3   \t");
+    ss.exceptions(std::stringstream::failbit);
+    EXPECT_NO_THROW(ss >> test);
+    EXPECT_EQ(c, test);
+  }
+}
+
+/////////////////////////////////////////////////
 TEST(Color, HSV)
 {
   math::Color clr;


### PR DESCRIPTION
The stream insertion operator is used in libsdformat to parse Color values, and as far as I know, alpha is already optional, but currently, if the exception mask for [`failbit`](https://en.cppreference.com/w/cpp/io/basic_ios/exceptions) is set ([we are doing that in libsdformat to catch more parsing errors](https://github.com/osrf/sdformat/pull/244)), the `operator>>` function will throw an exception. This PR keeps the current behavior by keeping alpha optional, but prevents an exception from being thrown.
