### PR TITLE
fix: add header for numeric_limits allowing build on ubuntu 16.04

### DIFF
--- a/src/RollingMean.cc
+++ b/src/RollingMean.cc
@@ -16,6 +16,7 @@
 */
 
 #include <numeric>
+#include <limits>
 #include <deque>
 #include "ignition/math/RollingMean.hh"
 


### PR DESCRIPTION
Seems that libstdc++ must have internally changed implicit header dependency graph such that `limits` was no longer implicitly included.

Added explicit dependency on `limits` to make it possible to compile `ign-math` in ubuntu 16.04