### PR TITLE
Add setter/getter for Pose's each element - Issue 35

### DIFF
--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -381,7 +381,7 @@ namespace ignition
       /// \return Value X of the origin of the pose.
       /// \note The return is made by value since
       /// Vector3<T>.X() is already a reference.
-      public: inline T X()
+      public: inline T &X()
       {
         return this->p.X();
       }
@@ -399,7 +399,7 @@ namespace ignition
       /// \return Value Y of the origin of the pose.
       /// \note The return is made by value since
       /// Vector3<T>.Y() is already a reference.
-      public: inline T Y()
+      public: inline T &Y()
       {
         return this->p.Y();
       }
@@ -417,7 +417,7 @@ namespace ignition
       /// \return Value Z of the origin of the pose.
       /// \note The return is made by value since
       /// Vector3<T>.Z() is already a reference.
-      public: inline T Z()
+      public: inline T &Z()
       {
         return this->p.Z();
       }
@@ -449,8 +449,8 @@ namespace ignition
       /// \return Roll value of the orientation.
       /// \note The return is made by value since
       ///  Quaternion<T>.Roll() is already a reference.
-      public: inline T Roll()
-      {
+      public: inline T &Roll()
+      { 
         return this->q.Roll();
       }
 
@@ -465,8 +465,6 @@ namespace ignition
 
       /// \brief Get the mutable Pitch value of the rotation.
       /// \return Pitch value of the orientation.
-      /// \note The return is made by value since
-      ///  Quaternion<T>.Pitch() is already a reference.
       public: inline T Pitch()
       {
         return this->q.Pitch();

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -438,6 +438,20 @@ namespace ignition
         return this->q.Roll();
       }
 
+      /// \brief Get the Pitch value of the rotation.
+      /// \return Pitch value of the orientation.
+      public: inline const T &Pitch() const
+      {
+        return this->q.Pitch();
+      }
+
+      /// \brief Get the mutable Pitch value of the rotation.
+      /// \return Pitch value of the orientation.
+      public: inline T &Pitch() 
+      {
+        return this->q.Pitch();
+      }
+
       /// \brief Stream insertion operator
       /// \param[in] _out output stream
       /// \param[in] _pose pose to output

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -372,7 +372,28 @@ namespace ignition
       /// \return Value X of the origin of the pose.
       public: inline const Vector3<T> &X() const
       {
-        return this->p.X;
+        return this->p.X();
+      }
+
+      /// \brief Get the mutable X value of the position.
+      /// \return Value X of the origin of the pose.
+      public: inline Vector3<T> &X() 
+      {
+        return this->p.X();
+      }
+
+      /// \brief Get the Y value of the position.
+      /// \return Value Y of the origin of the pose.
+      public: inline const Vector3<T> &Y() const
+      {
+        return this->p.Y();
+      }
+
+      /// \brief Get the mutable Y value of the position.
+      /// \return Value Y of the origin of the pose.
+      public: inline Vector3<T> &Y() 
+      {
+        return this->p.Y();
       }
 
       /// \brief Get the rotation.

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -465,7 +465,7 @@ namespace ignition
 
       /// \brief Get the mutable Pitch value of the rotation.
       /// \return Pitch value of the orientation.
-      public: inline T Pitch()
+      public: inline T &Pitch()
       {
         return this->q.Pitch();
       }
@@ -483,7 +483,7 @@ namespace ignition
       /// \return Yaw value of the orientation.
       /// \note The return is made by value since
       ///  Quaternion<T>.Yaw() is already a reference.
-      public: inline T Yaw()
+      public: inline T &Yaw()
       {
         return this->q.Yaw();
       }

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -396,6 +396,20 @@ namespace ignition
         return this->p.Y();
       }
 
+      /// \brief Get the Z value of the position.
+      /// \return Value Z of the origin of the pose.
+      public: inline const Vector3<T> &Z() const
+      {
+        return this->p.Z();
+      }
+
+      /// \brief Get the mutable Z value of the position.
+      /// \return Value Z of the origin of the pose.
+      public: inline Vector3<T> &Z() 
+      {
+        return this->p.Z();
+      }
+
       /// \brief Get the rotation.
       /// \return Quaternion representation of the rotation.
       public: inline const Quaternion<T> &Rot() const

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -436,15 +436,6 @@ namespace ignition
         return this->q.Roll();
       }
 
-      /// \brief Get the mutable Roll value of the rotation.
-      /// \return Roll value of the orientation.
-      /// \note The return is made by value since
-      ///  Quaternion<T>.Roll() is already a reference.
-      public: inline T &Roll()
-      {
-        return this->q.Roll();
-      }
-
       /// \brief Get the Pitch value of the rotation.
       /// \return Pitch value of the orientation.
       /// \note The return is made by value since
@@ -454,27 +445,11 @@ namespace ignition
         return this->q.Pitch();
       }
 
-      /// \brief Get the mutable Pitch value of the rotation.
-      /// \return Pitch value of the orientation.
-      public: inline T &Pitch()
-      {
-        return this->q.Pitch();
-      }
-
       /// \brief Get the Yaw value of the rotation.
       /// \return Yaw value of the orientation.
       /// \note The return is made by value since
       ///  Quaternion<T>.Yaw() is already a reference.
       public: inline const T Yaw() const
-      {
-        return this->q.Yaw();
-      }
-
-      /// \brief Get the mutable Yaw value of the rotation.
-      /// \return Yaw value of the orientation.
-      /// \note The return is made by value since
-      ///  Quaternion<T>.Yaw() is already a reference.
-      public: inline T &Yaw()
       {
         return this->q.Yaw();
       }

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -452,6 +452,20 @@ namespace ignition
         return this->q.Pitch();
       }
 
+      /// \brief Get the Yaw value of the rotation.
+      /// \return Yaw value of the orientation.
+      public: inline const T &Yaw() const
+      {
+        return this->q.Yaw();
+      }
+
+      /// \brief Get the mutable Yaw value of the rotation.
+      /// \return Yaw value of the orientation.
+      public: inline T &Yaw() 
+      {
+        return this->q.Yaw();
+      }
+
       /// \brief Stream insertion operator
       /// \param[in] _out output stream
       /// \param[in] _pose pose to output

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -368,6 +368,13 @@ namespace ignition
         return this->p;
       }
 
+      /// \brief Get the X value of the position.
+      /// \return Value X of the origin of the pose.
+      public: inline const Vector3<T> &X() const
+      {
+        return this->p.X;
+      }
+
       /// \brief Get the rotation.
       /// \return Quaternion representation of the rotation.
       public: inline const Quaternion<T> &Rot() const

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -377,13 +377,10 @@ namespace ignition
         return this->p.X();
       }
 
-      /// \brief Get the mutable X value of the position.
-      /// \return Value X of the origin of the pose.
-      /// \note The return is made by value since
-      /// Vector3<T>.X() is already a reference.
-      public: inline T &X()
+      /// \brief Set X value of the position.
+      public: inline void SetX(T x)
       {
-        return this->p.X();
+       this->p.X() = x;
       }
 
       /// \brief Get the Y value of the position.
@@ -395,13 +392,10 @@ namespace ignition
         return this->p.Y();
       }
 
-      /// \brief Get the mutable Y value of the position.
-      /// \return Value Y of the origin of the pose.
-      /// \note The return is made by value since
-      /// Vector3<T>.Y() is already a reference.
-      public: inline T &Y()
+      /// \brief Set the Y value of the position.
+      public: inline void SetY(T y)
       {
-        return this->p.Y();
+        this->p.Y() = y;
       }
 
       /// \brief Get the Z value of the position.
@@ -413,13 +407,10 @@ namespace ignition
         return this->p.Z();
       }
 
-      /// \brief Get the mutable Z value of the position.
-      /// \return Value Z of the origin of the pose.
-      /// \note The return is made by value since
-      /// Vector3<T>.Z() is already a reference.
-      public: inline T &Z()
+      /// \brief Set the Z value of the position.
+      public: inline void SetZ(T z)
       {
-        return this->p.Z();
+        this->p.Z() = z;
       }
 
       /// \brief Get the rotation.
@@ -450,7 +441,7 @@ namespace ignition
       /// \note The return is made by value since
       ///  Quaternion<T>.Roll() is already a reference.
       public: inline T &Roll()
-      { 
+      {
         return this->q.Roll();
       }
 

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -370,42 +370,48 @@ namespace ignition
 
       /// \brief Get the X value of the position.
       /// \return Value X of the origin of the pose.
-      public: inline const T &X() const
+      /// \note The return is made by value since Vector3<T>.X() is already a reference.
+      public: inline const T X() const
       {
         return this->p.X();
       }
 
       /// \brief Get the mutable X value of the position.
       /// \return Value X of the origin of the pose.
-      public: inline T &X() 
+      /// \note The return is made by value since Vector3<T>.X() is already a reference.
+      public: inline T X() 
       {
         return this->p.X();
       }
 
       /// \brief Get the Y value of the position.
       /// \return Value Y of the origin of the pose.
-      public: inline const T &Y() const
+      /// \note The return is made by value since Vector3<T>.Y() is already a reference.
+      public: inline const T Y() const
       {
         return this->p.Y();
       }
 
       /// \brief Get the mutable Y value of the position.
       /// \return Value Y of the origin of the pose.
-      public: inline T &Y() 
+      /// \note The return is made by value since Vector3<T>.Y() is already a reference.
+      public: inline T Y() 
       {
         return this->p.Y();
       }
 
       /// \brief Get the Z value of the position.
       /// \return Value Z of the origin of the pose.
-      public: inline const T &Z() const
+      /// \note The return is made by value since Vector3<T>.Z() is already a reference.
+      public: inline const T Z() const
       {
         return this->p.Z();
       }
 
       /// \brief Get the mutable Z value of the position.
       /// \return Value Z of the origin of the pose.
-      public: inline T &Z() 
+      /// \note The return is made by value since Vector3<T>.Z() is already a reference.
+      public: inline T Z() 
       {
         return this->p.Z();
       }
@@ -426,42 +432,48 @@ namespace ignition
 
       /// \brief Get the Roll value of the rotation.
       /// \return Roll value of the orientation.
-      public: inline const T &Roll() const
+      /// \note The return is made by value since Quaternion<T>.Roll() is already a reference.
+      public: inline const T Roll() const
       {
         return this->q.Roll();
       }
 
       /// \brief Get the mutable Roll value of the rotation.
       /// \return Roll value of the orientation.
-      public: inline T &Roll() 
+      /// \note The return is made by value since Quaternion<T>.Roll() is already a reference.
+      public: inline T Roll() 
       {
         return this->q.Roll();
       }
 
       /// \brief Get the Pitch value of the rotation.
       /// \return Pitch value of the orientation.
-      public: inline const T &Pitch() const
+      /// \note The return is made by value since Quaternion<T>.Pitch() is already a reference.
+      public: inline const T Pitch() const
       {
         return this->q.Pitch();
       }
 
       /// \brief Get the mutable Pitch value of the rotation.
       /// \return Pitch value of the orientation.
-      public: inline T &Pitch() 
+      /// \note The return is made by value since Quaternion<T>.Pitch() is already a reference.
+      public: inline T Pitch() 
       {
         return this->q.Pitch();
       }
 
       /// \brief Get the Yaw value of the rotation.
       /// \return Yaw value of the orientation.
-      public: inline const T &Yaw() const
+      /// \note The return is made by value since Quaternion<T>.Yaw() is already a reference.
+      public: inline const T Yaw() const
       {
         return this->q.Yaw();
       }
 
       /// \brief Get the mutable Yaw value of the rotation.
       /// \return Yaw value of the orientation.
-      public: inline T &Yaw() 
+      /// \note The return is made by value since Quaternion<T>.Yaw() is already a reference.
+      public: inline T Yaw() 
       {
         return this->q.Yaw();
       }

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -370,7 +370,8 @@ namespace ignition
 
       /// \brief Get the X value of the position.
       /// \return Value X of the origin of the pose.
-      /// \note The return is made by value since Vector3<T>.X() is already a reference.
+      /// \note The return is made by value since
+      /// Vector3<T>.X() is already a reference.
       public: inline const T X() const
       {
         return this->p.X();
@@ -378,15 +379,17 @@ namespace ignition
 
       /// \brief Get the mutable X value of the position.
       /// \return Value X of the origin of the pose.
-      /// \note The return is made by value since Vector3<T>.X() is already a reference.
-      public: inline T X() 
+      /// \note The return is made by value since
+      /// Vector3<T>.X() is already a reference.
+      public: inline T X()
       {
         return this->p.X();
       }
 
       /// \brief Get the Y value of the position.
       /// \return Value Y of the origin of the pose.
-      /// \note The return is made by value since Vector3<T>.Y() is already a reference.
+      /// \note The return is made by value since
+      /// Vector3<T>.Y() is already a reference.
       public: inline const T Y() const
       {
         return this->p.Y();
@@ -394,15 +397,17 @@ namespace ignition
 
       /// \brief Get the mutable Y value of the position.
       /// \return Value Y of the origin of the pose.
-      /// \note The return is made by value since Vector3<T>.Y() is already a reference.
-      public: inline T Y() 
+      /// \note The return is made by value since
+      /// Vector3<T>.Y() is already a reference.
+      public: inline T Y()
       {
         return this->p.Y();
       }
 
       /// \brief Get the Z value of the position.
       /// \return Value Z of the origin of the pose.
-      /// \note The return is made by value since Vector3<T>.Z() is already a reference.
+      /// \note The return is made by value since
+      /// Vector3<T>.Z() is already a reference.
       public: inline const T Z() const
       {
         return this->p.Z();
@@ -410,8 +415,9 @@ namespace ignition
 
       /// \brief Get the mutable Z value of the position.
       /// \return Value Z of the origin of the pose.
-      /// \note The return is made by value since Vector3<T>.Z() is already a reference.
-      public: inline T Z() 
+      /// \note The return is made by value since
+      /// Vector3<T>.Z() is already a reference.
+      public: inline T Z()
       {
         return this->p.Z();
       }
@@ -432,7 +438,8 @@ namespace ignition
 
       /// \brief Get the Roll value of the rotation.
       /// \return Roll value of the orientation.
-      /// \note The return is made by value since Quaternion<T>.Roll() is already a reference.
+      /// \note The return is made by value since
+      ///  Quaternion<T>.Roll() is already a reference.
       public: inline const T Roll() const
       {
         return this->q.Roll();
@@ -440,15 +447,17 @@ namespace ignition
 
       /// \brief Get the mutable Roll value of the rotation.
       /// \return Roll value of the orientation.
-      /// \note The return is made by value since Quaternion<T>.Roll() is already a reference.
-      public: inline T Roll() 
+      /// \note The return is made by value since
+      ///  Quaternion<T>.Roll() is already a reference.
+      public: inline T Roll()
       {
         return this->q.Roll();
       }
 
       /// \brief Get the Pitch value of the rotation.
       /// \return Pitch value of the orientation.
-      /// \note The return is made by value since Quaternion<T>.Pitch() is already a reference.
+      /// \note The return is made by value since
+      ///  Quaternion<T>.Pitch() is already a reference.
       public: inline const T Pitch() const
       {
         return this->q.Pitch();
@@ -456,15 +465,17 @@ namespace ignition
 
       /// \brief Get the mutable Pitch value of the rotation.
       /// \return Pitch value of the orientation.
-      /// \note The return is made by value since Quaternion<T>.Pitch() is already a reference.
-      public: inline T Pitch() 
+      /// \note The return is made by value since
+      ///  Quaternion<T>.Pitch() is already a reference.
+      public: inline T Pitch()
       {
         return this->q.Pitch();
       }
 
       /// \brief Get the Yaw value of the rotation.
       /// \return Yaw value of the orientation.
-      /// \note The return is made by value since Quaternion<T>.Yaw() is already a reference.
+      /// \note The return is made by value since
+      ///  Quaternion<T>.Yaw() is already a reference.
       public: inline const T Yaw() const
       {
         return this->q.Yaw();
@@ -472,8 +483,9 @@ namespace ignition
 
       /// \brief Get the mutable Yaw value of the rotation.
       /// \return Yaw value of the orientation.
-      /// \note The return is made by value since Quaternion<T>.Yaw() is already a reference.
-      public: inline T Yaw() 
+      /// \note The return is made by value since
+      ///  Quaternion<T>.Yaw() is already a reference.
+      public: inline T Yaw()
       {
         return this->q.Yaw();
       }

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -370,42 +370,42 @@ namespace ignition
 
       /// \brief Get the X value of the position.
       /// \return Value X of the origin of the pose.
-      public: inline const Vector3<T> &X() const
+      public: inline const T &X() const
       {
         return this->p.X();
       }
 
       /// \brief Get the mutable X value of the position.
       /// \return Value X of the origin of the pose.
-      public: inline Vector3<T> &X() 
+      public: inline T &X() 
       {
         return this->p.X();
       }
 
       /// \brief Get the Y value of the position.
       /// \return Value Y of the origin of the pose.
-      public: inline const Vector3<T> &Y() const
+      public: inline const T &Y() const
       {
         return this->p.Y();
       }
 
       /// \brief Get the mutable Y value of the position.
       /// \return Value Y of the origin of the pose.
-      public: inline Vector3<T> &Y() 
+      public: inline T &Y() 
       {
         return this->p.Y();
       }
 
       /// \brief Get the Z value of the position.
       /// \return Value Z of the origin of the pose.
-      public: inline const Vector3<T> &Z() const
+      public: inline const T &Z() const
       {
         return this->p.Z();
       }
 
       /// \brief Get the mutable Z value of the position.
       /// \return Value Z of the origin of the pose.
-      public: inline Vector3<T> &Z() 
+      public: inline T &Z() 
       {
         return this->p.Z();
       }
@@ -422,6 +422,20 @@ namespace ignition
       public: inline Quaternion<T> &Rot()
       {
         return this->q;
+      }
+
+      /// \brief Get the Roll value of the rotation.
+      /// \return Roll value of the orientation.
+      public: inline const T &Roll() const
+      {
+        return this->q.Roll();
+      }
+
+      /// \brief Get the mutable Roll value of the rotation.
+      /// \return Roll value of the orientation.
+      public: inline T &Roll() 
+      {
+        return this->q.Roll();
       }
 
       /// \brief Stream insertion operator

--- a/src/Pose_TEST.cc
+++ b/src/Pose_TEST.cc
@@ -141,7 +141,7 @@ TEST(PoseTest, Pose)
 TEST(PoseTest, ConstPose)
 {
   const math::Pose3d pose(0, 1, 2, 1, 0, 0);
-  
+
   EXPECT_TRUE(pose.Pos() == math::Vector3d(0, 1, 2));
   EXPECT_TRUE(pose.Rot() == math::Quaterniond(1, 0, 0));
 }
@@ -168,13 +168,12 @@ TEST(PoseTest, MutablePose)
 
   EXPECT_TRUE(pose.Pos() == math::Vector3d(10, 20, 30));
   EXPECT_TRUE(pose.Rot() == math::Quaterniond(1, 2, 1));
- }
+}
 
 /////////////////////////////////////////////////
 TEST(PoseTest, ConstPoseElements)
 {
   const math::Pose3d pose(0, 1, 2, 1, 1, 2);
- 
   EXPECT_DOUBLE_EQ(pose.X(), 0);
   EXPECT_DOUBLE_EQ(pose.Y(), 1);
   EXPECT_DOUBLE_EQ(pose.Z(), 2);
@@ -187,25 +186,15 @@ TEST(PoseTest, ConstPoseElements)
 TEST(PoseTest, MutablePoseElements)
 {
   math::Pose3d pose(1, 2, 3, 1.57, 1, 2);
-
   EXPECT_DOUBLE_EQ(pose.X(), 1);
   EXPECT_DOUBLE_EQ(pose.Y(), 2);
   EXPECT_DOUBLE_EQ(pose.Z(), 3);
-  EXPECT_DOUBLE_EQ(pose.Rot().Roll(), 1.57);
-  EXPECT_DOUBLE_EQ(pose.Rot().Pitch(), 1);
-  EXPECT_DOUBLE_EQ(pose.Rot().Yaw(), 2);
 
-  pose.X() = 10;
-  pose.Y() = 12;
-  pose.Z() = 13;
-  // pose.Roll() = 14; 
-  // pose.Pitch() = 15;
-  // pose.Yaw() = 16;
+  pose.SetX(10);
+  pose.SetY(12);
+  pose.SetZ(13);
 
   EXPECT_DOUBLE_EQ(pose.X(), 10);
   EXPECT_DOUBLE_EQ(pose.Y(), 12);
   EXPECT_DOUBLE_EQ(pose.Z(), 13);
-  // EXPECT_EQ(pose.Roll(), 14);
-  // EXPECT_EQ(pose.Pitch(), 15);
-  // EXPECT_EQ(pose.Yaw(), 16);
 }

--- a/src/Pose_TEST.cc
+++ b/src/Pose_TEST.cc
@@ -155,3 +155,25 @@ TEST(PoseTest, OperatorStreamOut)
   EXPECT_EQ(stream.str(), "0.1 1.2 2.3 0 0.1 1");
 }
 
+/////////////////////////////////////////////////
+TEST(PoseTest, PoseElements)
+{
+  const math::Pose3i pose(0, 1, 2, 0, 0, 0);
+
+  int x = pose.Pos().X();
+  int y = pose.Pos().Y();
+  int z = pose.Pos().Z();
+  int Roll = pose.Rot().Roll();
+  int Pitch = pose.Rot().Pitch();
+  int Yaw = pose.Rot().Yaw();
+
+
+  EXPECT_EQ(pose.X(),x);
+  EXPECT_EQ(pose.Y(),y);
+  EXPECT_EQ(pose.Z(),z);
+  EXPECT_EQ(pose.Roll(),Roll);
+  EXPECT_EQ(pose.Pitch(),Pitch);
+  EXPECT_EQ(pose.Yaw(),Yaw);
+
+
+}

--- a/src/Pose_TEST.cc
+++ b/src/Pose_TEST.cc
@@ -140,10 +140,10 @@ TEST(PoseTest, Pose)
 /////////////////////////////////////////////////
 TEST(PoseTest, ConstPose)
 {
-  const math::Pose3d pose(0, 1, 2, 0, 0, 0);
-
+  const math::Pose3d pose(0, 1, 2, 1, 0, 0);
+  
   EXPECT_TRUE(pose.Pos() == math::Vector3d(0, 1, 2));
-  EXPECT_TRUE(pose.Rot() == math::Quaterniond(0, 0, 0));
+  EXPECT_TRUE(pose.Rot() == math::Quaterniond(1, 0, 0));
 }
 
 /////////////////////////////////////////////////
@@ -168,44 +168,44 @@ TEST(PoseTest, MutablePose)
 
   EXPECT_TRUE(pose.Pos() == math::Vector3d(10, 20, 30));
   EXPECT_TRUE(pose.Rot() == math::Quaterniond(1, 2, 1));
-}
+ }
 
 /////////////////////////////////////////////////
 TEST(PoseTest, ConstPoseElements)
 {
-  const math::Pose3d pose(0, 1, 2, 0, 1, 2);
+  const math::Pose3d pose(0, 1, 2, 1, 1, 2);
  
   EXPECT_DOUBLE_EQ(pose.X(), 0);
   EXPECT_DOUBLE_EQ(pose.Y(), 1);
   EXPECT_DOUBLE_EQ(pose.Z(), 2);
-  EXPECT_DOUBLE_EQ(pose.Roll(), 0);
+  EXPECT_DOUBLE_EQ(pose.Roll(), 1);
   EXPECT_DOUBLE_EQ(pose.Pitch(), 1);
   EXPECT_DOUBLE_EQ(pose.Yaw(), 2);
 }
 
 /////////////////////////////////////////////////
-// TEST(PoseTest, MutablePoseElements)
-// {
-//   const math::Pose3i pose(1, 2, 3, 4, 5, 6);
+TEST(PoseTest, MutablePoseElements)
+{
+  math::Pose3d pose(1, 2, 3, 1.57, 1, 2);
 
-//   EXPECT_EQ(pose.X(), 1);
-//   EXPECT_EQ(pose.Y(), 2);
-//   EXPECT_EQ(pose.Z(), 3);
-//   EXPECT_EQ(pose.Rot().Roll(), 4);
-//   EXPECT_EQ(pose.Pitch(), 5);
-//   EXPECT_EQ(pose.Yaw(), 6);
+  EXPECT_DOUBLE_EQ(pose.X(), 1);
+  EXPECT_DOUBLE_EQ(pose.Y(), 2);
+  EXPECT_DOUBLE_EQ(pose.Z(), 3);
+  EXPECT_DOUBLE_EQ(pose.Rot().Roll(), 1.57);
+  EXPECT_DOUBLE_EQ(pose.Rot().Pitch(), 1);
+  EXPECT_DOUBLE_EQ(pose.Rot().Yaw(), 2);
 
-//   pose.X() = 10;
-//   pose.Y() = 12;
-//   pose.Z() = 13;
-//   pose.SetRoll(14); 
-//   pose.Pitch() = 15;
-//   pose.Yaw() = 16;
+  pose.X() = 10;
+  pose.Y() = 12;
+  pose.Z() = 13;
+  // pose.Roll() = 14; 
+  // pose.Pitch() = 15;
+  // pose.Yaw() = 16;
 
-//   EXPECT_EQ(pose.X(), 10);
-//   EXPECT_EQ(pose.Y(), 12);
-//   EXPECT_EQ(pose.Z(), 13);
-//   EXPECT_EQ(pose.Roll(), 14);
-//   EXPECT_EQ(pose.Pitch(), 15);
-//   EXPECT_EQ(pose.Yaw(), 16);
-// }
+  EXPECT_DOUBLE_EQ(pose.X(), 10);
+  EXPECT_DOUBLE_EQ(pose.Y(), 12);
+  EXPECT_DOUBLE_EQ(pose.Z(), 13);
+  // EXPECT_EQ(pose.Roll(), 14);
+  // EXPECT_EQ(pose.Pitch(), 15);
+  // EXPECT_EQ(pose.Yaw(), 16);
+}

--- a/src/Pose_TEST.cc
+++ b/src/Pose_TEST.cc
@@ -167,13 +167,10 @@ TEST(PoseTest, PoseElements)
   int Pitch = pose.Rot().Pitch();
   int Yaw = pose.Rot().Yaw();
 
-
-  EXPECT_EQ(pose.X(),x);
-  EXPECT_EQ(pose.Y(),y);
-  EXPECT_EQ(pose.Z(),z);
-  EXPECT_EQ(pose.Roll(),Roll);
-  EXPECT_EQ(pose.Pitch(),Pitch);
-  EXPECT_EQ(pose.Yaw(),Yaw);
-
-
+  EXPECT_EQ(pose.X(), x);
+  EXPECT_EQ(pose.Y(), y);
+  EXPECT_EQ(pose.Z(), z);
+  EXPECT_EQ(pose.Roll(), Roll);
+  EXPECT_EQ(pose.Pitch(), Pitch);
+  EXPECT_EQ(pose.Yaw(), Yaw);
 }

--- a/src/Pose_TEST.cc
+++ b/src/Pose_TEST.cc
@@ -183,7 +183,7 @@ TEST(PoseTest, ConstPoseElements)
 }
 
 /////////////////////////////////////////////////
-TEST(PoseTest, MutablePoseElements)
+TEST(PoseTest, SetPoseElements)
 {
   math::Pose3d pose(1, 2, 3, 1.57, 1, 2);
   EXPECT_DOUBLE_EQ(pose.X(), 1);

--- a/src/Pose_TEST.cc
+++ b/src/Pose_TEST.cc
@@ -156,23 +156,56 @@ TEST(PoseTest, OperatorStreamOut)
 }
 
 /////////////////////////////////////////////////
-TEST(PoseTest, ConstPoseElements)
+TEST(PoseTest, MutablePose)
 {
-  const math::Pose3i pose(0, 1, 2, 0, 0, 0);
+  math::Pose3d pose(0, 1, 2, 0, 0, 0);
 
-  int x = pose.Pos().X();
-  int y = pose.Pos().Y();
-  int z = pose.Pos().Z();
-  int roll = pose.Rot().Roll();
-  int pitch = pose.Rot().Pitch();
-  int yaw = pose.Rot().Yaw();
+  EXPECT_TRUE(pose.Pos() == math::Vector3d(0, 1, 2));
+  EXPECT_TRUE(pose.Rot() == math::Quaterniond(0, 0, 0));
 
-  EXPECT_EQ(pose.X(), x);
-  EXPECT_EQ(pose.Y(), y);
-  EXPECT_EQ(pose.Z(), z);
-  EXPECT_EQ(pose.Roll(), roll);
-  EXPECT_EQ(pose.Pitch(), pitch);
-  EXPECT_EQ(pose.Yaw(), yaw);
+  pose.Pos() = math::Vector3d(10, 20, 30);
+  pose.Rot() = math::Quaterniond(1, 2, 1);
+
+  EXPECT_TRUE(pose.Pos() == math::Vector3d(10, 20, 30));
+  EXPECT_TRUE(pose.Rot() == math::Quaterniond(1, 2, 1));
 }
 
+/////////////////////////////////////////////////
+TEST(PoseTest, ConstPoseElements)
+{
+  const math::Pose3d pose(0, 1, 2, 0, 1, 2);
+ 
+  EXPECT_DOUBLE_EQ(pose.X(), 0);
+  EXPECT_DOUBLE_EQ(pose.Y(), 1);
+  EXPECT_DOUBLE_EQ(pose.Z(), 2);
+  EXPECT_DOUBLE_EQ(pose.Roll(), 0);
+  EXPECT_DOUBLE_EQ(pose.Pitch(), 1);
+  EXPECT_DOUBLE_EQ(pose.Yaw(), 2);
+}
 
+/////////////////////////////////////////////////
+// TEST(PoseTest, MutablePoseElements)
+// {
+//   const math::Pose3i pose(1, 2, 3, 4, 5, 6);
+
+//   EXPECT_EQ(pose.X(), 1);
+//   EXPECT_EQ(pose.Y(), 2);
+//   EXPECT_EQ(pose.Z(), 3);
+//   EXPECT_EQ(pose.Rot().Roll(), 4);
+//   EXPECT_EQ(pose.Pitch(), 5);
+//   EXPECT_EQ(pose.Yaw(), 6);
+
+//   pose.X() = 10;
+//   pose.Y() = 12;
+//   pose.Z() = 13;
+//   pose.SetRoll(14); 
+//   pose.Pitch() = 15;
+//   pose.Yaw() = 16;
+
+//   EXPECT_EQ(pose.X(), 10);
+//   EXPECT_EQ(pose.Y(), 12);
+//   EXPECT_EQ(pose.Z(), 13);
+//   EXPECT_EQ(pose.Roll(), 14);
+//   EXPECT_EQ(pose.Pitch(), 15);
+//   EXPECT_EQ(pose.Yaw(), 16);
+// }

--- a/src/Pose_TEST.cc
+++ b/src/Pose_TEST.cc
@@ -156,21 +156,23 @@ TEST(PoseTest, OperatorStreamOut)
 }
 
 /////////////////////////////////////////////////
-TEST(PoseTest, PoseElements)
+TEST(PoseTest, ConstPoseElements)
 {
   const math::Pose3i pose(0, 1, 2, 0, 0, 0);
 
   int x = pose.Pos().X();
   int y = pose.Pos().Y();
   int z = pose.Pos().Z();
-  int Roll = pose.Rot().Roll();
-  int Pitch = pose.Rot().Pitch();
-  int Yaw = pose.Rot().Yaw();
+  int roll = pose.Rot().Roll();
+  int pitch = pose.Rot().Pitch();
+  int yaw = pose.Rot().Yaw();
 
   EXPECT_EQ(pose.X(), x);
   EXPECT_EQ(pose.Y(), y);
   EXPECT_EQ(pose.Z(), z);
-  EXPECT_EQ(pose.Roll(), Roll);
-  EXPECT_EQ(pose.Pitch(), Pitch);
-  EXPECT_EQ(pose.Yaw(), Yaw);
+  EXPECT_EQ(pose.Roll(), roll);
+  EXPECT_EQ(pose.Pitch(), pitch);
+  EXPECT_EQ(pose.Yaw(), yaw);
 }
+
+


### PR DESCRIPTION
Solved #35 

Add methods to Pose3.hh to get X,Y,Z,Roll,Pitch and Yaw directly, as suggested in the issue description : 

- pose.Pos.X() -> pose.X()
- pose.Pos.Y() -> pose.Y()
- pose.Pos.Z() -> pose.Z()
- pose.Rot.Roll() -> pose.Roll()
- pose.Rot.Pitch() -> pose.Pitch()
- pose.Rot.Yaw() -> pose.Yaw() 