### PR TITLE
Implement AxisAlignedBox Volume function

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Ignition Math 6.x.x
 
+1. Implement AxisAlignedBox Volume function
+    * [Pull request 126](https://github.com/ignitionrobotics/ign-math/pull/126)
+
 1. Add operator + for AxisAlignedBox and Vector3.
     * [Pull request 122](https://github.com/ignitionrobotics/ign-math/pull/122)
 

--- a/src/AxisAlignedBox.cc
+++ b/src/AxisAlignedBox.cc
@@ -284,6 +284,11 @@ std::tuple<bool, double, Vector3d>  AxisAlignedBox::Intersect(
   dir.Normalize();
   return this->Intersect(Line3d(_origin + dir * _min, _origin + dir * _max));
 }
+/////////////////////////////////////////////////
+double AxisAlignedBox::Volume() const
+{
+  return this->XLength() * this->YLength() * this->ZLength();
+}
 
 /////////////////////////////////////////////////
 // Find the intersection of a line from v0 to v1 and an

--- a/src/AxisAlignedBox_TEST.cc
+++ b/src/AxisAlignedBox_TEST.cc
@@ -253,6 +253,12 @@ TEST_F(ExampleAxisAlignedBox, Merge)
 }
 
 /////////////////////////////////////////////////
+TEST_F(ExampleAxisAlignedBox, Volume)
+{
+  EXPECT_DOUBLE_EQ(1.0, box.Volume());
+}
+
+/////////////////////////////////////////////////
 TEST(AxisAlignedBoxTest, OperatorEqual)
 {
   AxisAlignedBox box = AxisAlignedBox(Vector3d(1, 1, 1), Vector3d(3, 3, 3));
@@ -576,4 +582,14 @@ TEST(AxisAlignedBoxTest, Intersect)
   EXPECT_NEAR(std::get<1>(b.Intersect(Vector3d(1.2, 0, 0.5),
       Vector3d(-0.707107, 0, -0.707107), 0, 1000)), dist, 1e-5);
   EXPECT_EQ(pt, Vector3d(1, 0, 0.3));
+}
+
+/////////////////////////////////////////////////
+TEST(AxisAlignedBoxTest, Volume)
+{
+  AxisAlignedBox box;
+  EXPECT_DOUBLE_EQ(0.0, box.Volume());
+
+  AxisAlignedBox box2(math::Vector3d(-1, -2, -3), math::Vector3d(1, 2, 3));
+  EXPECT_DOUBLE_EQ(48.0, box2.Volume());
 }


### PR DESCRIPTION
This PR added the implementation for the AxisAlignedBox::Volume function.

I noticed that several other functions in the AxisAlignedBox class are missing implementations, e.g. `DensityFromMass`, `MassMatrix`, `Material`. I not sure if these functions are are supposed to be moved to the AxisAlignedBox class when the `Box` class was refactored in this [pull request](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-math/pull-requests/257/page/1). Maybe @nkoenig knows more about this?