### PR TITLE
Add Abs, Dot and AbsDot and respective tests to Vector4

### DIFF
--- a/include/ignition/math/Vector4.hh
+++ b/include/ignition/math/Vector4.hh
@@ -113,6 +113,43 @@ namespace ignition
         }
       }
 
+      /// \brief Return the dot product of this vector and another vector
+      /// \param[in] _v the vector
+      /// \return the dot product
+      public: T Dot(const Vector4<T> &_v) const
+      {
+        return this->data[0] * _v[0] +
+               this->data[1] * _v[1] +
+               this->data[2] * _v[2] +
+               this->data[3] * _v[3];
+      }
+
+      /// \brief Return the absolute dot product of this vector and
+      /// another vector. This is similar to the Dot function, except the
+      /// absolute value of each component of the vector is used.
+      ///
+      /// result = abs(x1 * x2) + abs(y1 * y2) + abs(z1 * z2) + abs(w1 * w2)
+      ///
+      /// \param[in] _v the vector
+      /// \return The absolute dot product
+      public: T AbsDot(const Vector4<T> &_v) const
+      {
+        return std::abs(this->data[0] * _v[0]) +
+               std::abs(this->data[1] * _v[1]) +
+               std::abs(this->data[2] * _v[2]) +
+               std::abs(this->data[3] * _v[3]);
+      }
+
+      /// \brief Get the absolute value of the vector
+      /// \return a vector with positive elements
+      public: Vector4 Abs() const
+      {
+        return Vector4(std::abs(this->data[0]),
+                       std::abs(this->data[1]),
+                       std::abs(this->data[2]),
+                       std::abs(this->data[3]));
+      }
+
       /// \brief Set the contents of the vector
       /// \param[in] _x value along x axis
       /// \param[in] _y value along y axis

--- a/src/Vector4_TEST.cc
+++ b/src/Vector4_TEST.cc
@@ -61,6 +61,16 @@ TEST(Vector4dTest, Vector4d)
   v.Set(2, 4, 6, 8);
   EXPECT_EQ(v, math::Vector4d(2, 4, 6, 8));
 
+  // ::DotProd
+  EXPECT_TRUE(math::equal(60.0, v.Dot(math::Vector4d(1, 2, 3, 4)), 1e-2));
+
+  // ::AbsDotProd
+  v1.Set(-1, -2, -3, -4);
+  EXPECT_TRUE(math::equal(60.0, v.AbsDot(v1), 1e-2));
+
+  // ::GetAbs
+  EXPECT_TRUE(v1.Abs() == math::Vector4d(1, 2, 3, 4));
+
   // ::operator= vector4
   v = v1;
   EXPECT_EQ(v, v1);

--- a/src/Vector4_TEST.cc
+++ b/src/Vector4_TEST.cc
@@ -70,6 +70,7 @@ TEST(Vector4dTest, Vector4d)
 
   // ::GetAbs
   EXPECT_TRUE(v1.Abs() == math::Vector4d(1, 2, 3, 4));
+  EXPECT_TRUE(v.Abs() == math::Vector4d(2, 4, 6, 8));
 
   // ::operator= vector4
   v = v1;


### PR DESCRIPTION
Resolves #71 .

This implements the functions Abs(), Dot(Vector4) and AbsDot(Vector4) in Vector4 API, similar to the existing same functions in Vector3.

It enables Vector4 objects to perform:

```
vec4.Abs();
vec4_a.Dot(vec4_b);
vec4_a.AbsDot(vec4_b);
```

Did all checks and tests.