### PR TITLE
Doc Ruby Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ The optional Eigen component of Ignition Math requires:
     sudo apt-get install libeigen3-dev
     ```
 
+The optional Ruby tests of Ignition Math requires:
+
+ * [Ruby](https://www.ruby-lang.org/). Refer to the [Ruby Documentation](https://www.ruby-lang.org/downloads/) for installation instructions. On Ubuntu Systems `apt-get` can be used to install Ubuntu Package `ruby-dev`:
+
+    ```
+    sudo apt-get install ruby-dev
+    ```
+
+  * [Swig](http://www.swig.org/). Refer to the [Swig Documentation](http://www.swig.org/download.html) for installation instructions. On Ubuntu Systems `apt-get` can be used to install Swig:
+
+    ```
+    sudo apt-get install swig
+    ```
+
 ### Building from source
 
 1. Clone the repository
@@ -161,6 +175,28 @@ Follow these steps to run tests and static code analysis in your clone of this r
     ```
     make codecheck
     ```
+
+## Ruby Tests
+
+### Usage
+
+The C++ classes are available in Ruby code by interfaces files (.i) used by swig to build a C++ extension module.
+
+The interfaces and Ruby test codes are in `src` folder. To use a C++ class in Ruby you need:
+
+1. Create an interface file describing the class as in Swig and Ruby reference at [The Ruby-to-C/C++ Mapping](http://www.swig.org/Doc1.3/Ruby.html#Ruby_nn11)
+
+2. Include the interface file in `/src/ing_math.i`
+
+3. Create the Ruby file and import the class as in Swig and Ruby reference at [C++ Classes](http://www.swig.org/Doc1.3/Ruby.html#Ruby_nn18)
+
+### Tests
+
+`make test` already run all tests, including the ones made in Ruby, but you can run an Ruby test individually using
+
+```
+ctest -R Ruby_TEST.rb
+```
 
 # Folder Structure
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Follow these steps to run tests and static code analysis in your clone of this r
 
 The C++ classes are available in Ruby code by interface files (`.i`) used by swig to build a C++ extension module.
 
-The interfaces and Ruby test codes are in `src` folder. To use a C++ class in Ruby you need:
+The interfaces and Ruby test codes are in the `src` folder. To use a C++ class in Ruby you need to:
 
 1. Create an interface file describing the class as in Swig and Ruby reference at [The Ruby-to-C/C++ Mapping](http://www.swig.org/Doc1.3/Ruby.html#Ruby_nn11)
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Follow these steps to run tests and static code analysis in your clone of this r
 
 ### Usage
 
-The C++ classes are available in Ruby code by interfaces files (.i) used by swig to build a C++ extension module.
+The C++ classes are available in Ruby code by interface files (`.i`) used by swig to build a C++ extension module.
 
 The interfaces and Ruby test codes are in `src` folder. To use a C++ class in Ruby you need:
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The optional Eigen component of Ignition Math requires:
 
 The optional Ruby tests of Ignition Math require:
 
- * [Ruby](https://www.ruby-lang.org/). Refer to the [Ruby Documentation](https://www.ruby-lang.org/downloads/) for installation instructions. On Ubuntu Systems `apt-get` can be used to install Ubuntu Package `ruby-dev`:
+ * [Ruby](https://www.ruby-lang.org/). Refer to the [Ruby Documentation](https://www.ruby-lang.org/downloads/) for installation instructions. On Ubuntu systems `apt-get` can be used to install Ubuntu Package `ruby-dev`:
 
     ```
     sudo apt-get install ruby-dev

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The optional Eigen component of Ignition Math requires:
     sudo apt-get install libeigen3-dev
     ```
 
-The optional Ruby tests of Ignition Math requires:
+The optional Ruby tests of Ignition Math require:
 
  * [Ruby](https://www.ruby-lang.org/). Refer to the [Ruby Documentation](https://www.ruby-lang.org/downloads/) for installation instructions. On Ubuntu Systems `apt-get` can be used to install Ubuntu Package `ruby-dev`:
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The optional Ruby tests of Ignition Math require:
     sudo apt-get install ruby-dev
     ```
 
-  * [Swig](http://www.swig.org/). Refer to the [Swig Documentation](http://www.swig.org/download.html) for installation instructions. On Ubuntu Systems `apt-get` can be used to install Swig:
+  * [Swig](http://www.swig.org/). Refer to the [Swig Documentation](http://www.swig.org/download.html) for installation instructions. On Ubuntu systems `apt-get` can be used to install Swig:
 
     ```
     sudo apt-get install swig

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The interfaces and Ruby test codes are in the `src` folder. To use a C++ class i
 
 ### Tests
 
-`make test` already run all tests, including the ones made in Ruby, but you can run an Ruby test individually using
+`make test` already runs all tests, including the ones made in Ruby, but you can run a Ruby test individually using
 
 ```
 ctest -R Ruby_TEST.rb


### PR DESCRIPTION
Resolves #136 .

Add install prerequisites and testing subsection Ruby Tests.

Tried to do an guide for absolute beginners, on how to create an interface and use this in a test file, using `Swig` documentation important points as reference.