### PR TITLE
Removed repeated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,6 @@ classes and functions designed for robotic applications.
 
 [Install](#markdown-header-install)
 
-* [Binary Install](#markdown-header-binary-install)
-
-* [Source Install](#markdown-header-source-install)
-
-    * [Prerequisites](#markdown-header-prerequisites)
-
-    * [Building from Source](#markdown-header-building-from-source)
-
 [Usage](#markdown-header-usage)
 
 [Documentation](#markdown-header-documentation)
@@ -60,55 +52,7 @@ Math types.
 
 # Install
 
-We recommend following the [Binary Install](#markdown-header-binary-install) instructions to get up and running as quickly and painlessly as possible.
-
-The [Source Install](#markdown-header-source-install) instructions should be used if you need the very latest software improvements, you need to modify the code, or you plan to make a contribution.
-
-## Binary Install
-
-On Ubuntu systems, `apt-get` can be used to install `ignition-math`:
-
-```
-sudo apt install libignition-math<#>-dev
-```
-
-Be sure to replace `<#>` with a number value, such as 1 or 2, depending on
-which version you need.
-
-## Source Install
-
-Source installation can be performed in UNIX systems by first installing the
-necessary prerequisites followed by building from source.
-
-### Prerequisites
-
-The optional Eigen component of Ignition Math requires:
-
-  * [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page). Refer to the [Eigen Documentation](http://eigen.tuxfamily.org/index.php?title=Main_Page#Documentation) for installation instructions. On Ubuntu systems, `apt-get` can be used to install Eigen:
-
-    ```
-    sudo apt-get install libeigen3-dev
-    ```
-
-### Building from source
-
-1. Clone the repository
-
-    ```
-    git clone https://github.com/ignitionrobotics/ign-math
-    ```
-
-2. Configure and build
-
-    ```
-    cd ign-math; mkdir build; cd build; cmake ..; make
-    ```
-
-3. Optionally, install Ignition Math
-
-    ```
-    sudo make install
-    ```
+Review the [tutorial section](tutorials/installation.md).
 
 # Usage
 

--- a/tutorials/installation.md
+++ b/tutorials/installation.md
@@ -2,12 +2,30 @@
 
 Next Tutorial: \ref cppgetstarted
 
-## Overview
+# Overview
 
 This tutorial describes how to install Ignition Math on Linux, Mac OS X and
 Windows via either a binary distribution or from source.
 
-## Ubuntu Linux
+[Install](#markdown-header-install)
+
+* [Binary Install](#markdown-header-binary-install)
+
+* [Source Install](#markdown-header-source-install)
+
+    * [Prerequisites](#markdown-header-prerequisites)
+
+    * [Building from Source](#markdown-header-building-from-source)
+
+# Install
+
+We recommend following the [Binary Install](#markdown-header-binary-install) instructions to get up and running as quickly and painlessly as possible.
+
+The [Source Install](#markdown-header-source-install) instructions should be used if you need the very latest software improvements, you need to modify the code, or you plan to make a contribution.
+
+## Binary Install
+
+### Ubuntu Linux
 
 Setup your computer to accept software from
 *packages.osrfoundation.org*:
@@ -25,6 +43,57 @@ wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 Install Ignition Math:
 
 ```
-sudo apt-get update
-sudo apt-get install libignition-math7-dev
+sudo apt install libignition-math<#>-dev
 ```
+
+Be sure to replace `<#>` with a number value, such as 1 or 2, depending on
+which version you need.
+
+## Source Install
+
+Source installation can be performed in UNIX systems by first installing the
+necessary prerequisites followed by building from source.
+
+### Prerequisites
+
+The optional Eigen component of Ignition Math requires:
+
+  * [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page). Refer to the [Eigen Documentation](http://eigen.tuxfamily.org/index.php?title=Main_Page#Documentation) for installation instructions. On Ubuntu systems, `apt-get` can be used to install Eigen:
+
+    ```
+    sudo apt-get install libeigen3-dev
+    ```
+
+The optional Ruby tests of Ignition Math require:
+
+ * [Ruby](https://www.ruby-lang.org/). Refer to the [Ruby Documentation](https://www.ruby-lang.org/downloads/) for installation instructions. On Ubuntu systems `apt-get` can be used to install Ubuntu Package `ruby-dev`:
+
+    ```
+    sudo apt-get install ruby-dev
+    ```
+
+  * [Swig](http://www.swig.org/). Refer to the [Swig Documentation](http://www.swig.org/download.html) for installation instructions. On Ubuntu systems `apt-get` can be used to install Swig:
+
+    ```
+    sudo apt-get install swig
+    ```
+
+### Building from source
+
+1. Clone the repository
+
+    ```
+    git clone https://github.com/ignitionrobotics/ign-math
+    ```
+
+2. Configure and build
+
+    ```
+    cd ign-math; mkdir build; cd build; cmake ..; make
+    ```
+
+3. Optionally, install Ignition Math
+
+    ```
+    sudo make install
+    ```


### PR DESCRIPTION
This PR is related with this issue https://github.com/ignitionrobotics/docs/issues/14

Moved install instructions to the tutorials folder.

Signed-off-by: ahcorde <ahcorde@gmail.com>