### PR TITLE
Fix two windows warnings

### DIFF
--- a/include/ignition/math/Helpers.hh
+++ b/include/ignition/math/Helpers.hh
@@ -840,7 +840,7 @@ namespace ignition
         const std::string &_timeString)
     {
       std::chrono::steady_clock::time_point timePoint =
-        math::secNsecToTimePoint(-1, 0);
+        math::secNsecToTimePoint(0, 0);
 
       if (_timeString.empty())
         return timePoint;
@@ -908,7 +908,7 @@ namespace ignition
         {
           numberDays = std::stoi(dayString);
         }
-        catch (const std::out_of_range &oor)
+        catch (const std::out_of_range &)
         {
           return timePoint;
         }


### PR DESCRIPTION
Fixes two warnings found by @scpeters [here](https://github.com/ignitionrobotics/ign-math/pull/152#discussion_r483876964)

Unfortunately, I realized after the fact that I was passing in -1 into the `math::secNsecTimePoint()` function which takes type `const uint64_t` to indicate an invalid string. I suppose we're just going to have to return 0 if an invalid string is entered for now unless we want to add an extra parameter to `stringToTimePoint` that will be stored with the success of the operation.

Signed-off-by: John Shepherd <john@openrobotics.org>