### PR TITLE
Add missing include

### DIFF
--- a/include/ignition/math/Color.hh
+++ b/include/ignition/math/Color.hh
@@ -18,6 +18,7 @@
 #define IGNITION_MATH_COLOR_HH_
 
 #include <iostream>
+#include <cctype>
 
 #include <ignition/math/Helpers.hh>
 #include <ignition/math/Vector3.hh>


### PR DESCRIPTION
See https://github.com/conda-forge/libignition-math4-feedstock/pull/9 which fails without this fix added in https://github.com/conda-forge/libignition-math4-feedstock/pull/10

Also http://www.cplusplus.com/reference/cctype/isspace/

/cc @traversaro 