### PR TITLE
Document Pose::operator*()

### DIFF
--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -258,6 +258,9 @@ namespace ignition
       }
 
       /// \brief Multiplication operator.
+      /// A is the transform from O to P specified in frame O
+      /// B is the transform from P to Q specified in frame P
+      /// then, A * B is the transform from O to Q specified in frame O
       /// \param[in] _pose The pose to mutlipy by.
       /// \return The resulting pose.
       public: Pose3<T> operator*(const Pose3<T> &_pose) const

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -258,9 +258,8 @@ namespace ignition
       }
 
       /// \brief Multiplication operator.
-      /// A is the transform from O to P specified in frame O
-      /// B is the transform from P to Q specified in frame P
-      /// then, A * B is the transform from O to Q specified in frame O
+      /// Given X_OP (frame P relative to O) and X_PQ (frame Q relative to P)
+      /// then X_OQ = X_OP * X_PQ (frame Q relative to O).
       /// \param[in] _pose The pose to mutlipy by.
       /// \return The resulting pose.
       public: Pose3<T> operator*(const Pose3<T> &_pose) const


### PR DESCRIPTION
Adds some documentation for `Pose::operator*()`. If I understand correctly, it looks like `B + A` is the same as `A * B`, but [operator+ is discouraged](https://github.com/ignitionrobotics/ign-math/issues/60).