### PR TITLE
Add construction tests for Vector2, Vector3, Vector4, Quaternion, and Pose

### DIFF
--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -231,7 +231,7 @@ namespace ignition
         return *this;
       }
 
-      /// \brief Equal operator
+      /// \brief Assignment operator
       /// \param[in] _pose Pose3<T> to copy
       public: Pose3<T> &operator=(const Pose3<T> &_pose)
       {

--- a/include/ignition/math/Quaternion.hh
+++ b/include/ignition/math/Quaternion.hh
@@ -105,7 +105,7 @@ namespace ignition
       /// \brief Destructor
       public: ~Quaternion() {}
 
-      /// \brief Equal operator
+      /// \brief Assignment operator
       /// \param[in] _qt Quaternion<T> to copy
       public: Quaternion<T> &operator=(const Quaternion<T> &_qt)
       {

--- a/src/Pose_TEST.cc
+++ b/src/Pose_TEST.cc
@@ -23,6 +23,38 @@
 using namespace ignition;
 
 /////////////////////////////////////////////////
+TEST(PoseTest, Construction)
+{
+  math::Pose3d pose(1, 0, 0, 0, 0, 0);
+
+  // Copy constructor
+  math::Pose3d pose2(pose);
+  EXPECT_EQ(pose2, pose);
+
+  // Copy operator
+  math::Pose3d pose3;
+  pose3 = pose;
+  EXPECT_EQ(pose3, pose);
+
+  // Move constructor
+  math::Pose3d pose4(std::move(pose));
+  EXPECT_EQ(pose4, pose2);
+  pose = pose4;
+  EXPECT_EQ(pose, pose2);
+
+  // Move operator
+  math::Pose3d pose5;
+  pose5 = std::move(pose2);
+  EXPECT_EQ(pose5, pose3);
+  pose2 = pose5;
+  EXPECT_EQ(pose2, pose3);
+
+  // Inequality
+  math::Pose3d pose6;
+  EXPECT_NE(pose6, pose3);
+}
+
+/////////////////////////////////////////////////
 TEST(PoseTest, Pose)
 {
   {

--- a/src/Quaternion_TEST.cc
+++ b/src/Quaternion_TEST.cc
@@ -27,6 +27,38 @@
 using namespace ignition;
 
 /////////////////////////////////////////////////
+TEST(QuaternionTest, Construction)
+{
+  math::Quaterniond q(0, 0, 0, 1);
+
+  // Copy constructor
+  math::Quaterniond q2(q);
+  EXPECT_EQ(q2, q);
+
+  // Copy operator
+  math::Quaterniond q3;
+  q3 = q;
+  EXPECT_EQ(q3, q);
+
+  // Move constructor
+  math::Quaterniond q4(std::move(q));
+  EXPECT_EQ(q4, q2);
+  q = q4;
+  EXPECT_EQ(q, q2);
+
+  // Move operator
+  math::Quaterniond q5;
+  q5 = std::move(q2);
+  EXPECT_EQ(q5, q3);
+  q2 = q5;
+  EXPECT_EQ(q2, q3);
+
+  // Inequality
+  math::Quaterniond q6;
+  EXPECT_NE(q6, q3);
+}
+
+/////////////////////////////////////////////////
 TEST(QuaternionTest, Unit)
 {
   math::Quaterniond q;
@@ -512,7 +544,7 @@ TEST(QuaternionTest, Slerp)
 }
 
 /////////////////////////////////////////////////
-TEST(QuaterniondTest, From2Axes)
+TEST(QuaternionTest, From2Axes)
 {
   math::Vector3d v1(1.0, 0.0, 0.0);
   math::Vector3d v2(0.0, 1.0, 0.0);

--- a/src/Vector2_TEST.cc
+++ b/src/Vector2_TEST.cc
@@ -24,6 +24,38 @@
 using namespace ignition;
 
 /////////////////////////////////////////////////
+TEST(Vector2Test, Construction)
+{
+  math::Vector2d vec(1, 0);
+
+  // Copy constructor
+  math::Vector2d vec2(vec);
+  EXPECT_EQ(vec2, vec);
+
+  // Copy operator
+  math::Vector2d vec3;
+  vec3 = vec;
+  EXPECT_EQ(vec3, vec);
+
+  // Move constructor
+  math::Vector2d vec4(std::move(vec));
+  EXPECT_EQ(vec4, vec2);
+  vec = vec4;
+  EXPECT_EQ(vec, vec2);
+
+  // Move operator
+  math::Vector2d vec5;
+  vec5 = std::move(vec2);
+  EXPECT_EQ(vec5, vec3);
+  vec2 = vec5;
+  EXPECT_EQ(vec2, vec3);
+
+  // Inequality
+  math::Vector2d vec6;
+  EXPECT_NE(vec6, vec3);
+}
+
+/////////////////////////////////////////////////
 TEST(Vector2Test, Vector2)
 {
   {
@@ -124,7 +156,6 @@ TEST(Vector2Test, Vector2)
   v.Set(10, 6);
   v *= math::Vector2d(2, 4);
   EXPECT_TRUE(v == math::Vector2d(20, 24));
-
 
   // ::IsFinite
   EXPECT_TRUE(v.IsFinite());
@@ -272,7 +303,7 @@ TEST(Vector2Test, OperatorStreamOut)
 }
 
 /////////////////////////////////////////////////
-TEST(Vector2dTest, Add)
+TEST(Vector2Test, Add)
 {
   math::Vector2d vec1(0.1, 0.2);
   math::Vector2d vec2(1.1, 2.2);
@@ -313,7 +344,7 @@ TEST(Vector2dTest, Add)
 }
 
 /////////////////////////////////////////////////
-TEST(Vector2dTest, Sub)
+TEST(Vector2Test, Sub)
 {
   math::Vector2d vec1(0.1, 0.2);
   math::Vector2d vec2(1.1, 2.2);
@@ -391,7 +422,7 @@ TEST(Vector2Test, Multiply)
 }
 
 /////////////////////////////////////////////////
-TEST(Vector2dTest, Length)
+TEST(Vector2Test, Length)
 {
   // Zero vector
   EXPECT_DOUBLE_EQ(math::Vector2d::Zero.Length(), 0.0);

--- a/src/Vector3_TEST.cc
+++ b/src/Vector3_TEST.cc
@@ -26,7 +26,39 @@
 using namespace ignition;
 
 /////////////////////////////////////////////////
-TEST(Vector3Test, Vector3d)
+TEST(Vector3dTest, Construction)
+{
+  math::Vector3d vec(1, 0, 0);
+
+  // Copy constructor
+  math::Vector3d vec2(vec);
+  EXPECT_EQ(vec2, vec);
+
+  // Copy operator
+  math::Vector3d vec3;
+  vec3 = vec;
+  EXPECT_EQ(vec3, vec);
+
+  // Move constructor
+  math::Vector3d vec4(std::move(vec));
+  EXPECT_EQ(vec4, vec2);
+  vec = vec4;
+  EXPECT_EQ(vec, vec2);
+
+  // Move operator
+  math::Vector3d vec5;
+  vec5 = std::move(vec2);
+  EXPECT_EQ(vec5, vec3);
+  vec2 = vec5;
+  EXPECT_EQ(vec2, vec3);
+
+  // Inequality
+  math::Vector3d vec6;
+  EXPECT_NE(vec6, vec3);
+}
+
+/////////////////////////////////////////////////
+TEST(Vector3dTest, Vector3d)
 {
   math::Vector3d v;
 
@@ -390,7 +422,7 @@ TEST(Vector3dTest, NotEqual)
 
 /////////////////////////////////////////////////
 // Test Equal function with specified tolerance
-TEST(Vector2Test, EqualTolerance)
+TEST(Vector3dTest, EqualTolerance)
 {
   EXPECT_FALSE(math::Vector3d::Zero.Equal(math::Vector3d::One, 1e-6));
   EXPECT_FALSE(math::Vector3d::Zero.Equal(math::Vector3d::One, 1e-3));

--- a/src/Vector4_TEST.cc
+++ b/src/Vector4_TEST.cc
@@ -24,6 +24,38 @@
 using namespace ignition;
 
 /////////////////////////////////////////////////
+TEST(Vector4dTest, Construction)
+{
+  math::Vector4d vec(1, 0, 0, 0);
+
+  // Copy constructor
+  math::Vector4d vec2(vec);
+  EXPECT_EQ(vec2, vec);
+
+  // Copy operator
+  math::Vector4d vec3;
+  vec3 = vec;
+  EXPECT_EQ(vec3, vec);
+
+  // Move constructor
+  math::Vector4d vec4(std::move(vec));
+  EXPECT_EQ(vec4, vec2);
+  vec = vec4;
+  EXPECT_EQ(vec, vec2);
+
+  // Move operator
+  math::Vector4d vec5;
+  vec5 = std::move(vec2);
+  EXPECT_EQ(vec5, vec3);
+  vec2 = vec5;
+  EXPECT_EQ(vec2, vec3);
+
+  // Inequality
+  math::Vector4d vec6;
+  EXPECT_NE(vec6, vec3);
+}
+
+/////////////////////////////////////////////////
 TEST(Vector4dTest, Vector4d)
 {
   {
@@ -226,7 +258,7 @@ TEST(Vector4dTest, Min)
 
 /////////////////////////////////////////////////
 // Test Equal function with specified tolerance
-TEST(Vector2Test, EqualTolerance)
+TEST(Vector4dTest, EqualTolerance)
 {
   EXPECT_FALSE(math::Vector4d::Zero.Equal(math::Vector4d::One, 1e-6));
   EXPECT_FALSE(math::Vector4d::Zero.Equal(math::Vector4d::One, 1e-3));
@@ -337,7 +369,7 @@ TEST(Vector4dTest, OperatorStreamOut)
 }
 
 /////////////////////////////////////////////////
-TEST(Vector4Test, Multiply)
+TEST(Vector4dTest, Multiply)
 {
   math::Vector4d v(0.1, -4.2, 11.1, 8.4);
 


### PR DESCRIPTION
The classes are already moveable. The error reported in the issue comes from the fact that the operation is a copy assignment to unique_ptr, and not a move assignment.

Closes #76

Signed-off-by: Nick Lamprianidis <nlamprian@gmail.com>