### PR TITLE
Split test cases

### DIFF
--- a/src/Quaternion_TEST.cc
+++ b/src/Quaternion_TEST.cc
@@ -310,9 +310,6 @@ TEST(QuaternionTest, Math)
   q.Normalize();
   EXPECT_TRUE(q == math::Quaterniond(0.182574, 0.365148, 0.547723, 0.730297));
 
-  math::Quaterniond q2 = q.Normalized();
-  EXPECT_TRUE(q2 == math::Quaterniond(0.182574, 0.365148, 0.547723, 0.730297));
-
   EXPECT_TRUE(math::equal(q.Roll(), 1.4289, 1e-3));
   EXPECT_TRUE(math::equal(q.Pitch(), -0.339837, 1e-3));
   EXPECT_TRUE(math::equal(q.Yaw(), 2.35619, 1e-3));

--- a/src/Quaternion_TEST.cc
+++ b/src/Quaternion_TEST.cc
@@ -276,13 +276,21 @@ TEST(QuaternionTest, MathExp)
 }
 
 /////////////////////////////////////////////////
-TEST(QuaternionTest, Math)
+TEST(QuaternionTest, MathInvert)
 {
   math::Quaterniond q(IGN_PI*0.1, IGN_PI*0.5, IGN_PI);
   EXPECT_TRUE(q == math::Quaterniond(0.110616, -0.698401, 0.110616, 0.698401));
 
   q.Invert();
   EXPECT_TRUE(q == math::Quaterniond(0.110616, 0.698401, -0.110616, -0.698401));
+}
+
+
+/////////////////////////////////////////////////
+TEST(QuaternionTest, Math)
+{
+  math::Quaterniond q(IGN_PI*0.1, IGN_PI*0.5, IGN_PI);
+  EXPECT_TRUE(q == math::Quaterniond(0.110616, -0.698401, 0.110616, 0.698401));
 
   q.Axis(0, 1, 0, IGN_PI);
   EXPECT_TRUE(q == math::Quaterniond(6.12303e-17, 0, 1, 0));

--- a/src/Quaternion_TEST.cc
+++ b/src/Quaternion_TEST.cc
@@ -302,6 +302,8 @@ TEST(QuaternionTest, Math)
   q.Normalize();
   EXPECT_TRUE(q == math::Quaterniond(0.182574, 0.365148, 0.547723, 0.730297));
 
+  math::Quaterniond q2 = q.Normalized();
+  EXPECT_TRUE(q2 == math::Quaterniond(0.182574, 0.365148, 0.547723, 0.730297));
 
   EXPECT_TRUE(math::equal(q.Roll(), 1.4289, 1e-3));
   EXPECT_TRUE(math::equal(q.Pitch(), -0.339837, 1e-3));

--- a/src/Quaternion_TEST.cc
+++ b/src/Quaternion_TEST.cc
@@ -251,6 +251,28 @@ TEST(QuaternionTest, MathLog)
 
   EXPECT_TRUE(q.Log() ==
       math::Quaterniond(0, -1.02593, 0.162491, 1.02593));
+
+  math::Quaterniond q1 = q;
+  q1.W(2.0);
+  EXPECT_TRUE(q1.Log() ==
+      math::Quaterniond(0, -0.698401, 0.110616, 0.698401));
+}
+
+/////////////////////////////////////////////////
+TEST(QuaternionTest, MathExp)
+{
+  math::Quaterniond q(IGN_PI*0.1, IGN_PI*0.5, IGN_PI);
+  EXPECT_TRUE(q == math::Quaterniond(0.110616, -0.698401, 0.110616, 0.698401));
+
+  EXPECT_TRUE(q.Exp() ==
+    math::Quaterniond(0.545456, -0.588972, 0.093284, 0.588972));
+
+  math::Quaterniond q1 = q;
+  q1.X(0.000000001);
+  q1.Y(0.0);
+  q1.Z(0.0);
+  q1.W(0.0);
+  EXPECT_TRUE(q1.Exp() == math::Quaterniond(1, 0, 0, 0));
 }
 
 /////////////////////////////////////////////////
@@ -258,20 +280,6 @@ TEST(QuaternionTest, Math)
 {
   math::Quaterniond q(IGN_PI*0.1, IGN_PI*0.5, IGN_PI);
   EXPECT_TRUE(q == math::Quaterniond(0.110616, -0.698401, 0.110616, 0.698401));
-
-  EXPECT_TRUE(q.Exp() ==
-      math::Quaterniond(0.545456, -0.588972, 0.093284, 0.588972));
-
-  math::Quaterniond q1 = q;
-  q1.W(2.0);
-  EXPECT_TRUE(q1.Log() ==
-      math::Quaterniond(0, -0.698401, 0.110616, 0.698401));
-
-  q1.X(0.000000001);
-  q1.Y(0.0);
-  q1.Z(0.0);
-  q1.W(0.0);
-  EXPECT_TRUE(q1.Exp() == math::Quaterniond(1, 0, 0, 0));
 
   q.Invert();
   EXPECT_TRUE(q == math::Quaterniond(0.110616, 0.698401, -0.110616, -0.698401));

--- a/src/Quaternion_TEST.cc
+++ b/src/Quaternion_TEST.cc
@@ -244,13 +244,20 @@ TEST(QuaternionTest, Integrate)
 }
 
 /////////////////////////////////////////////////
-TEST(QuaternionTest, Math)
+TEST(QuaternionTest, MathLog)
 {
   math::Quaterniond q(IGN_PI*0.1, IGN_PI*0.5, IGN_PI);
   EXPECT_TRUE(q == math::Quaterniond(0.110616, -0.698401, 0.110616, 0.698401));
 
   EXPECT_TRUE(q.Log() ==
       math::Quaterniond(0, -1.02593, 0.162491, 1.02593));
+}
+
+/////////////////////////////////////////////////
+TEST(QuaternionTest, Math)
+{
+  math::Quaterniond q(IGN_PI*0.1, IGN_PI*0.5, IGN_PI);
+  EXPECT_TRUE(q == math::Quaterniond(0.110616, -0.698401, 0.110616, 0.698401));
 
   EXPECT_TRUE(q.Exp() ==
       math::Quaterniond(0.545456, -0.588972, 0.093284, 0.588972));


### PR DESCRIPTION
Separate some test cases in order to make it easier to handle regression. These demands appeared during the [conversation](https://github.com/ignitionrobotics/ign-math/pull/169#pullrequestreview-514051714) with @chapulina and @j-rivero 