### PR TITLE
Include ellipsoid as a math shape

### DIFF
--- a/include/ignition/math/Ellipsoid.hh
+++ b/include/ignition/math/Ellipsoid.hh
@@ -25,9 +25,6 @@ namespace ignition
 {
   namespace math
   {
-    // Foward declarations
-    class EllipsoidPrivate;
-
     // Inline bracket to help doxygen filtering.
     inline namespace IGNITION_MATH_VERSION_NAMESPACE {
     //

--- a/include/ignition/math/Ellipsoid.hh
+++ b/include/ignition/math/Ellipsoid.hh
@@ -47,7 +47,7 @@ namespace ignition
 
       /// \brief Construct a ellipsoid with a Vector3 of three radii.
       /// \param[in] _radii The three radii (x, y, z) defining this ellipsoid
-      public: Ellipsoid(const Vector3<Precision> &_radii);
+      public: explicit Ellipsoid(const Vector3<Precision> &_radii);
 
       /// \brief Construct a ellipsoid with three radii and a material.
       /// \param[in] _radii The three radii (x, y, z) defining this ellipsoid

--- a/include/ignition/math/Ellipsoid.hh
+++ b/include/ignition/math/Ellipsoid.hh
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
 */
-#ifndef IGNITION_MATH_CAPSULE_HH_
-#define IGNITION_MATH_CAPSULE_HH_
+#ifndef IGNITION_MATH_ELLIPSOID_HH_
+#define IGNITION_MATH_ELLIPSOID_HH_
 
 #include <optional>
 #include "ignition/math/MassMatrix3.hh"

--- a/include/ignition/math/Ellipsoid.hh
+++ b/include/ignition/math/Ellipsoid.hh
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_MATH_CAPSULE_HH_
+#define IGNITION_MATH_CAPSULE_HH_
+
+#include <optional>
+#include "ignition/math/MassMatrix3.hh"
+#include "ignition/math/Material.hh"
+
+namespace ignition
+{
+  namespace math
+  {
+    // Foward declarations
+    class EllipsoidPrivate;
+
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_MATH_VERSION_NAMESPACE {
+    //
+    /// \class Ellipsoid Ellipsoid.hh ignition/math/Ellipsoid.hh
+    /// \brief A representation of a general ellipsoid.
+    ///
+    /// The ellipsoid class supports defining a ellipsoid with three radii and
+    /// material properties. Radii are in meters. See Material for more on
+    /// material properties.
+    /// \tparam Precision Scalar numeric type.
+    template<typename Precision>
+    class Ellipsoid
+    {
+      /// \brief Default constructor. The default radius and length are both
+      /// zero.
+      public: Ellipsoid() = default;
+
+      /// \brief Construct a ellipsoid with a Vector3 of three radii.
+      /// \param[in] _radii The three radii (x, y, z) defining this ellipsoid
+      public: Ellipsoid(const Vector3<Precision> &_radii);
+
+      /// \brief Construct a ellipsoid with three radii and a material.
+      /// \param[in] _radii The three radii (x, y, z) defining this ellipsoid
+      /// \param[in] _mat Material property for the ellipsoid.
+      public: Ellipsoid(const Vector3<Precision> &_radii,
+                  const Material &_mat);
+
+      /// \brief Get the radius in meters.
+      /// \return The radius of the ellipsoid in meters.
+      public: Vector3<Precision> Radii() const;
+
+      /// \brief Set the radius in meters.
+      /// \param[in] _radius The radius of the ellipsoid in meters.
+      public: void SetRadii(const Vector3<Precision> &_radii);
+
+      /// \brief Get the material associated with this ellipsoid.
+      /// \return The material assigned to this ellipsoid
+      public: const Material &Mat() const;
+
+      /// \brief Set the material associated with this ellipsoid.
+      /// \param[in] _mat The material assigned to this ellipsoid
+      public: void SetMat(const Material &_mat);
+
+      /// \brief Get the mass matrix for this ellipsoid. This function
+      /// is only meaningful if the ellipsoid's radii and material
+      /// have been set.
+      /// \return The computed mass matrix if parameters are valid
+      /// (radius > 0), (length > 0), and (density > 0). Otherwise
+      /// std::nullopt is returned.
+      public: std::optional< MassMatrix3<Precision> > MassMatrix() const;
+
+      /// \brief Check if this ellipsoid is equal to the provided ellipsoid.
+      /// Radius, length, and material properties will be checked.
+      public: bool operator==(const Ellipsoid &_ellipsoid) const;
+
+      /// \brief Get the volume of the ellipsoid in m^3.
+      /// \return Volume of the ellipsoid in m^3.
+      public: Precision Volume() const;
+
+      /// \brief Compute the ellipsoid's density given a mass value. The
+      /// ellipsoid is assumed to be solid with uniform density. This
+      /// function requires the ellipsoid's radius and length to be set to
+      /// values greater than zero. The Material of the ellipsoid is ignored.
+      /// \param[in] _mass Mass of the ellipsoid, in kg. This value should be
+      /// greater than zero.
+      /// \return Density of the ellipsoid in kg/m^3. A NaN is returned
+      /// if radius, length or _mass is <= 0.
+      public: Precision DensityFromMass(const Precision _mass) const;
+
+      /// \brief Set the density of this ellipsoid based on a mass value.
+      /// Density is computed using
+      /// Precision DensityFromMass(const Precision _mass) const. The
+      /// ellipsoid is assumed to be solid with uniform density. This
+      /// function requires the ellipsoid's radius and length to be set to
+      /// values greater than zero. The existing Material density value is
+      /// overwritten only if the return value from this true.
+      /// \param[in] _mass Mass of the ellipsoid, in kg. This value should be
+      /// greater than zero.
+      /// \return True if the density was set. False is returned if the
+      /// ellipsoid's radius, length, or the _mass value are <= 0.
+      /// \sa Precision DensityFromMass(const Precision _mass) const
+      public: bool SetDensityFromMass(const Precision _mass);
+
+      /// \brief Radius of the ellipsoid.
+      private: Vector3<Precision> radii = Vector3<Precision>::Zero;
+
+      /// \brief the ellipsoid's material.
+      private: Material material;
+    };
+
+    /// \typedef Ellipsoid<int> Ellipsoidi
+    /// \brief Ellipsoid with integer precision.
+    typedef Ellipsoid<int> Ellipsoidi;
+
+    /// \typedef Ellipsoid<double> Ellipsoidd
+    /// \brief Ellipsoid with double precision.
+    typedef Ellipsoid<double> Ellipsoidd;
+
+    /// \typedef Ellipsoid<float> Ellipsoidf
+    /// \brief Ellipsoid with float precision.
+    typedef Ellipsoid<float> Ellipsoidf;
+    }
+  }
+}
+#include "ignition/math/detail/Ellipsoid.hh"
+
+#endif

--- a/include/ignition/math/detail/Ellipsoid.hh
+++ b/include/ignition/math/detail/Ellipsoid.hh
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
 */
-#ifndef IGNITION_MATH_DETAIL_ELLIPSE_HH_
-#define IGNITION_MATH_DETAIL_ELLIPSE_HH_
+#ifndef IGNITION_MATH_DETAIL_ELLIPSOID_HH_
+#define IGNITION_MATH_DETAIL_ELLIPSOID_HH_
 
 #include <limits>
 #include <optional>

--- a/include/ignition/math/detail/Ellipsoid.hh
+++ b/include/ignition/math/detail/Ellipsoid.hh
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
 */
-#ifndef IGNITION_MATH_DETAIL_CAPSULE_HH_
-#define IGNITION_MATH_DETAIL_CAPSULE_HH_
+#ifndef IGNITION_MATH_DETAIL_ELLIPSE_HH_
+#define IGNITION_MATH_DETAIL_ELLIPSE_HH_
 
 #include <limits>
 #include <optional>
@@ -76,7 +76,7 @@ bool Ellipsoid<T>::operator==(const Ellipsoid &_ellipsoid) const
 template<typename T>
 std::optional< MassMatrix3<T> > Ellipsoid<T>::MassMatrix() const
 {
-  if (this->radii.X() < 0 || this->radii.Y() < 0 || this->radii.Z() < 0)
+  if (this->radii.X() <= 0 || this->radii.Y() <= 0 || this->radii.Z() <= 0)
     return std::nullopt;
 
   // mass and inertia of ellipsoid taken from

--- a/include/ignition/math/detail/Ellipsoid.hh
+++ b/include/ignition/math/detail/Ellipsoid.hh
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_MATH_DETAIL_CAPSULE_HH_
+#define IGNITION_MATH_DETAIL_CAPSULE_HH_
+
+#include <limits>
+#include <optional>
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/Inertial.hh>
+
+namespace ignition
+{
+namespace math
+{
+
+//////////////////////////////////////////////////
+template<typename T>
+Ellipsoid<T>::Ellipsoid(const Vector3<T> &_radii) : radii(_radii) {}
+
+//////////////////////////////////////////////////
+template<typename T>
+Ellipsoid<T>::Ellipsoid(const Vector3<T> &_radii, const Material &_mat)
+: radii(_radii), material(_mat) {}
+
+//////////////////////////////////////////////////
+template<typename T>
+Vector3<T> Ellipsoid<T>::Radii() const
+{
+  return this->radii;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+void Ellipsoid<T>::SetRadii(const Vector3<T> &_radii)
+{
+  this->radii = _radii;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+const Material &Ellipsoid<T>::Mat() const
+{
+  return this->material;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+void Ellipsoid<T>::SetMat(const Material &_mat)
+{
+  this->material = _mat;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+bool Ellipsoid<T>::operator==(const Ellipsoid &_ellipsoid) const
+{
+  return this->radii == _ellipsoid.radii &&
+    this->material == _ellipsoid.material;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+std::optional< MassMatrix3<T> > Ellipsoid<T>::MassMatrix() const
+{
+  if (this->radii.X() < 0 || this->radii.Y() < 0 || this->radii.Z() < 0)
+    return std::nullopt;
+
+  // mass and inertia of ellipsoid taken from
+  // https://en.wikipedia.org/wiki/Ellipsoid
+  const T mass = this->material.Density() * this->Volume();
+  const T x2 = std::pow(this->radii.X(), 2);
+  const T y2 = std::pow(this->radii.Y(), 2);
+  const T z2 = std::pow(this->radii.Z(), 2);
+  const T ixx = (mass / 5.) * (y2 + z2);
+  const T iyy = (mass / 5.) * (x2 + z2);
+  const T izz = (mass / 5.) * (x2 + y2);
+  MassMatrix3<T> matrix(mass, Vector3(ixx, iyy, izz), Vector3<T>::Zero);
+  if (!matrix.IsValid())
+  {
+    return std::nullopt;
+  }
+
+  return matrix;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+T Ellipsoid<T>::Volume() const
+{
+  constexpr T kFourThirdsPi = 4. * IGN_PI / 3.;
+  return kFourThirdsPi * this->radii.X() * this->radii.Y() * this->radii.Z();
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+bool Ellipsoid<T>::SetDensityFromMass(const T _mass)
+{
+  T newDensity = this->DensityFromMass(_mass);
+  if (isnan(newDensity))
+    return false;
+
+  this->material.SetDensity(newDensity);
+  return true;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+T Ellipsoid<T>::DensityFromMass(const T _mass) const
+{
+  if (this->radii.X() <= 0 || this->radii.Y() <= 0 || this->radii.Z() <=0
+    || _mass <= 0)
+    return std::numeric_limits<T>::quiet_NaN();
+
+  return _mass / this->Volume();
+}
+
+}
+}
+#endif

--- a/include/ignition/math/detail/Ellipsoid.hh
+++ b/include/ignition/math/detail/Ellipsoid.hh
@@ -88,13 +88,8 @@ std::optional< MassMatrix3<T> > Ellipsoid<T>::MassMatrix() const
   const T ixx = (mass / 5.) * (y2 + z2);
   const T iyy = (mass / 5.) * (x2 + z2);
   const T izz = (mass / 5.) * (x2 + y2);
-  MassMatrix3<T> matrix(mass, Vector3(ixx, iyy, izz), Vector3<T>::Zero);
-  if (!matrix.IsValid())
-  {
-    return std::nullopt;
-  }
-
-  return matrix;
+  return std::make_optional<MassMatrix3<T>>(
+    mass, Vector3(ixx, iyy, izz), Vector3<T>::Zero);
 }
 
 //////////////////////////////////////////////////

--- a/src/Ellipsoid_TEST.cc
+++ b/src/Ellipsoid_TEST.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gtest/gtest.h>
+#include <cmath>
+#include <iostream>
+
+#include "ignition/math/Ellipsoid.hh"
+#include "ignition/math/Helpers.hh"
+#include "ignition/math/Vector3.hh"
+
+using namespace ignition;
+
+/////////////////////////////////////////////////
+TEST(EllipsoidTest, Constructor)
+{
+  // Default constructor
+  {
+    math::Ellipsoidd ellipsoid;
+    EXPECT_EQ(math::Vector3d::Zero, ellipsoid.Radii());
+    EXPECT_EQ(math::Material(), ellipsoid.Mat());
+
+    math::Ellipsoidd ellipsoid2;
+    EXPECT_EQ(ellipsoid, ellipsoid2);
+  }
+
+  // Vector3 of radii constructor
+  {
+    const math::Vector3d expectedRadii(1.0, 2.0, 3.0);
+    math::Ellipsoidd ellipsoid(expectedRadii);
+    EXPECT_EQ(expectedRadii, ellipsoid.Radii());
+    EXPECT_EQ(math::Material(), ellipsoid.Mat());
+
+    math::Ellipsoidd ellipsoid2(expectedRadii);
+    EXPECT_EQ(ellipsoid, ellipsoid2);
+  }
+
+  // Vector3 of radii and material
+  {
+    const math::Vector3d expectedRadii(1.0, 2.0, 3.0);
+    const math::Material expectedMaterial(math::MaterialType::WOOD);
+    math::Ellipsoidd ellipsoid(expectedRadii, expectedMaterial);
+    EXPECT_EQ(expectedRadii, ellipsoid.Radii());
+    EXPECT_EQ(expectedMaterial, ellipsoid.Mat());
+
+    math::Ellipsoidd ellipsoid2(expectedRadii, expectedMaterial);
+    EXPECT_EQ(ellipsoid, ellipsoid2);
+  }
+}
+
+//////////////////////////////////////////////////
+TEST(EllipsoidTest, Mutators)
+{
+  math::Ellipsoidd ellipsoid;
+  EXPECT_EQ(math::Vector3d::Zero, ellipsoid.Radii());
+  EXPECT_EQ(math::Material(), ellipsoid.Mat());
+
+  const math::Vector3d expectedRadii(1.0, 2.0, 3.0);
+  ellipsoid.SetRadii(expectedRadii);
+
+  const math::Material expectedMaterial(math::MaterialType::PINE);
+  ellipsoid.SetMat(expectedMaterial);
+
+  EXPECT_EQ(expectedRadii, ellipsoid.Radii());
+  EXPECT_EQ(expectedMaterial, ellipsoid.Mat());
+}
+
+//////////////////////////////////////////////////
+TEST(EllipsoidTest, VolumeAndDensity)
+{
+  double mass = 1.0;
+  // Basic sphere
+  math::Ellipsoidd ellipsoid(2. * math::Vector3d::One);
+
+  double expectedVolume = (4. / 3.) * IGN_PI * std::pow(2.0, 3);
+  EXPECT_DOUBLE_EQ(expectedVolume, ellipsoid.Volume());
+
+  double expectedDensity = mass / expectedVolume;
+  EXPECT_DOUBLE_EQ(expectedDensity, ellipsoid.DensityFromMass(mass));
+
+  math::Ellipsoidd ellipsoid2(math::Vector3d(1, 10, 100));
+  expectedVolume = (4. / 3.) * IGN_PI * 1. * 10. * 100.;
+  EXPECT_DOUBLE_EQ(expectedVolume, ellipsoid2.Volume());
+
+  expectedDensity = mass / expectedVolume;
+  EXPECT_DOUBLE_EQ(expectedDensity, ellipsoid2.DensityFromMass(mass));
+
+  // Check bad cases
+  math::Ellipsoidd ellipsoid3(math::Vector3d::Zero);
+  EXPECT_TRUE(math::isnan(ellipsoid3.DensityFromMass(mass)));
+
+  math::Ellipsoidd ellipsoid4(-math::Vector3d::One);
+  EXPECT_TRUE(math::isnan(ellipsoid4.DensityFromMass(mass)));
+
+  math::Ellipsoidd ellipsoid5(math::Vector3d(-1, 1, 1));
+  EXPECT_TRUE(math::isnan(ellipsoid5.DensityFromMass(mass)));
+
+  math::Ellipsoidd ellipsoid6(math::Vector3d(-1, -1, 1));
+  EXPECT_TRUE(math::isnan(ellipsoid6.DensityFromMass(mass)));
+}
+
+//////////////////////////////////////////////////
+TEST(EllipsoidTest, Mass)
+{
+  const double mass = 2.0;
+  math::Ellipsoidd ellipsoid(math::Vector3d(1, 10, 100));
+  ellipsoid.SetDensityFromMass(mass);
+
+  const double ixx = (mass / 5.0) * (10. * 10. + 100. * 100.);
+  const double iyy = (mass / 5.0) * (1. * 1. + 100. * 100.);
+  const double izz = (mass / 5.0) * (1. * 1. + 10. * 10.);
+  math::MassMatrix3d expectedMassMat(
+    mass, math::Vector3d(ixx, iyy, izz), math::Vector3d::Zero);
+
+  const auto massMat = ellipsoid.MassMatrix();
+  ASSERT_NE(std::nullopt, massMat);
+  EXPECT_EQ(expectedMassMat, *massMat);
+  EXPECT_EQ(expectedMassMat.DiagonalMoments(), massMat->DiagonalMoments());
+  EXPECT_DOUBLE_EQ(expectedMassMat.Mass(), massMat->Mass());
+
+  // Zero case
+  const math::Ellipsoidd ellipsoid2;
+  const math::MassMatrix3d zeroMass;
+  EXPECT_EQ(zeroMass, ellipsoid2.MassMatrix());
+
+  // Check bad cases
+  const math::Ellipsoidd ellipsoid3(-math::Vector3d::One);
+  EXPECT_EQ(std::nullopt, ellipsoid3.MassMatrix());
+
+  const math::Ellipsoidd ellipsoid4(math::Vector3d(-1, 1, 1));
+  EXPECT_EQ(std::nullopt, ellipsoid4.MassMatrix());
+
+  const math::Ellipsoidd ellipsoid5(math::Vector3d(-1, -1, 1));
+  EXPECT_EQ(std::nullopt, ellipsoid5.MassMatrix());
+}

--- a/src/Ellipsoid_TEST.cc
+++ b/src/Ellipsoid_TEST.cc
@@ -133,8 +133,7 @@ TEST(EllipsoidTest, Mass)
 
   // Zero case
   const math::Ellipsoidd ellipsoid2;
-  const math::MassMatrix3d zeroMass;
-  EXPECT_EQ(zeroMass, ellipsoid2.MassMatrix());
+  EXPECT_EQ(std::nullopt, ellipsoid2.MassMatrix());
 
   // Check bad cases
   const math::Ellipsoidd ellipsoid3(-math::Vector3d::One);

--- a/src/Ellipsoid_TEST.cc
+++ b/src/Ellipsoid_TEST.cc
@@ -100,16 +100,16 @@ TEST(EllipsoidTest, VolumeAndDensity)
 
   // Check bad cases
   math::Ellipsoidd ellipsoid3(math::Vector3d::Zero);
-  EXPECT_TRUE(math::isnan(ellipsoid3.DensityFromMass(mass)));
+  EXPECT_FALSE(ellipsoid3.SetDensityFromMass(mass));
 
   math::Ellipsoidd ellipsoid4(-math::Vector3d::One);
-  EXPECT_TRUE(math::isnan(ellipsoid4.DensityFromMass(mass)));
+  EXPECT_FALSE(ellipsoid4.SetDensityFromMass(mass));
 
   math::Ellipsoidd ellipsoid5(math::Vector3d(-1, 1, 1));
-  EXPECT_TRUE(math::isnan(ellipsoid5.DensityFromMass(mass)));
+  EXPECT_FALSE(ellipsoid5.SetDensityFromMass(mass));
 
   math::Ellipsoidd ellipsoid6(math::Vector3d(-1, -1, 1));
-  EXPECT_TRUE(math::isnan(ellipsoid6.DensityFromMass(mass)));
+  EXPECT_FALSE(ellipsoid6.SetDensityFromMass(mass));
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
This follows #163 pretty closely, but I'm happy to make changes where needed for this own class.

I noticed that the API for different shapes has diverged, and it may also be worth revisiting how bad parameters are dealt with across the different shapes.

Signed-off-by: Stephen Brawner <brawner@gmail.com>