### PR TITLE
Remove unnecessary copy constructor declaration from Box

### DIFF
--- a/include/ignition/math/Box.hh
+++ b/include/ignition/math/Box.hh
@@ -82,10 +82,6 @@ namespace ignition
       public: Box(const Vector3<Precision> &_size,
                   const ignition::math::Material &_mat);
 
-      /// \brief Copy Constructor.
-      /// \param[in]  _b Box to copy.
-      public: Box(const Box<Precision> &_b);
-
       /// \brief Destructor.
       public: virtual ~Box() = default;
 


### PR DESCRIPTION
The copy constructor `Box::Box(const Box<Precision> &)` was declared, but was never defined causing a link error if anyone used it. I believe the compiler generated copy constructor is sufficient, so I have removed the declaration.