### PR TITLE
Relax expectations about zero in SpeedLimiter_TEST to make ARM happy

### DIFF
--- a/src/SpeedLimiter_TEST.cc
+++ b/src/SpeedLimiter_TEST.cc
@@ -57,8 +57,8 @@ TEST(SpeedLimiterTest, Default)
   EXPECT_DOUBLE_EQ(5.0, vel);
 
   vel = 0.0;
-  EXPECT_DOUBLE_EQ(0.0, limiter.Limit(vel, 4.0, 3.0, 1ms));
-  EXPECT_DOUBLE_EQ(0.0, vel);
+  EXPECT_NEAR(0.0, limiter.Limit(vel, 4.0, 3.0, 1ms), 1e-6);
+  EXPECT_NEAR(0.0, vel, 1e-6);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compilation on some ARM builds

## Summary

Some ARM packaging jobs are failing with problems on the precision of zero in test under SpeedLimiter:
```
[ RUN      ] SpeedLimiterTest.Default
/var/lib/jenkins/workspace/ign-math6-debbuilder/build/ignition-math-6.8.0/src/SpeedLimiter_TEST.cc:60: Failure
Expected equality of these values:
  0.0
    Which is: 0
  limiter.Limit(vel, 4.0, 3.0, 1ms)
    Which is: -8.3266726846886741e-17
[  FAILED  ] SpeedLimiterTest.Default (6 ms)
```

With this patch the build compiles: https://build.osrfoundation.org/job/ign-math6-debbuilder/734/ 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)

**Note to maintainers**: Remember to use **Squash-Merge**