### PR TITLE
👩‍🌾 Don't use std::pow with integers in Vectors

### DIFF
--- a/include/ignition/math/Vector2.hh
+++ b/include/ignition/math/Vector2.hh
@@ -87,7 +87,7 @@ namespace ignition
       /// \return The length
       public: T Length() const
       {
-        return sqrt(this->SquaredLength());
+        return static_cast<T>(sqrt(this->SquaredLength()));
       }
 
       /// \brief Returns the square of the length (magnitude) of the vector

--- a/include/ignition/math/Vector2.hh
+++ b/include/ignition/math/Vector2.hh
@@ -94,8 +94,9 @@ namespace ignition
       /// \return The squared length
       public: T SquaredLength() const
       {
-        return std::pow(this->data[0], 2)
-             + std::pow(this->data[1], 2);
+        return
+          this->data[0] * this->data[0] +
+          this->data[1] * this->data[1];
       }
 
       /// \brief Normalize the vector length

--- a/include/ignition/math/Vector3.hh
+++ b/include/ignition/math/Vector3.hh
@@ -97,9 +97,10 @@ namespace ignition
       /// \return the distance
       public: T Distance(const Vector3<T> &_pt) const
       {
-        return sqrt((this->data[0]-_pt[0])*(this->data[0]-_pt[0]) +
+        return static_cast<T>(sqrt(
+                    (this->data[0]-_pt[0])*(this->data[0]-_pt[0]) +
                     (this->data[1]-_pt[1])*(this->data[1]-_pt[1]) +
-                    (this->data[2]-_pt[2])*(this->data[2]-_pt[2]));
+                    (this->data[2]-_pt[2])*(this->data[2]-_pt[2])));
       }
 
       /// \brief Calc distance to the given point
@@ -116,7 +117,7 @@ namespace ignition
       /// \return the length
       public: T Length() const
       {
-        return sqrt(this->SquaredLength());
+        return static_cast<T>(sqrt(this->SquaredLength()));
       }
 
       /// \brief Return the square of the length (magnitude) of the vector

--- a/include/ignition/math/Vector3.hh
+++ b/include/ignition/math/Vector3.hh
@@ -123,9 +123,10 @@ namespace ignition
       /// \return the squared length
       public: T SquaredLength() const
       {
-        return std::pow(this->data[0], 2)
-             + std::pow(this->data[1], 2)
-             + std::pow(this->data[2], 2);
+        return
+          this->data[0] * this->data[0] +
+          this->data[1] * this->data[1] +
+          this->data[2] * this->data[2];
       }
 
       /// \brief Normalize the vector length

--- a/include/ignition/math/Vector4.hh
+++ b/include/ignition/math/Vector4.hh
@@ -106,10 +106,11 @@ namespace ignition
       /// \return the length
       public: T SquaredLength() const
       {
-        return std::pow(this->data[0], 2)
-             + std::pow(this->data[1], 2)
-             + std::pow(this->data[2], 2)
-             + std::pow(this->data[3], 2);
+        return
+          this->data[0] * this->data[0] +
+          this->data[1] * this->data[1] +
+          this->data[2] * this->data[2] +
+          this->data[3] * this->data[3];
       }
 
       /// \brief Round to near whole number.

--- a/include/ignition/math/Vector4.hh
+++ b/include/ignition/math/Vector4.hh
@@ -78,10 +78,11 @@ namespace ignition
       /// \return the distance
       public: T Distance(const Vector4<T> &_pt) const
       {
-        return sqrt((this->data[0]-_pt[0])*(this->data[0]-_pt[0]) +
+        return static_cast<T>(sqrt(
+                    (this->data[0]-_pt[0])*(this->data[0]-_pt[0]) +
                     (this->data[1]-_pt[1])*(this->data[1]-_pt[1]) +
                     (this->data[2]-_pt[2])*(this->data[2]-_pt[2]) +
-                    (this->data[3]-_pt[3])*(this->data[3]-_pt[3]));
+                    (this->data[3]-_pt[3])*(this->data[3]-_pt[3])));
       }
 
       /// \brief Calc distance to the given point
@@ -99,7 +100,7 @@ namespace ignition
       /// \return The length
       public: T Length() const
       {
-        return sqrt(this->SquaredLength());
+        return static_cast<T>(sqrt(this->SquaredLength()));
       }
 
       /// \brief Return the square of the length (magnitude) of the vector

--- a/src/Vector2_TEST.cc
+++ b/src/Vector2_TEST.cc
@@ -436,5 +436,10 @@ TEST(Vector2Test, Length)
   math::Vector2d v(0.1, -4.2);
   EXPECT_NEAR(v.Length(), 4.20119030752, 1e-10);
   EXPECT_DOUBLE_EQ(v.SquaredLength(), 17.65);
+
+  // Integer vector
+  math::Vector2i vi(3, 4);
+  EXPECT_EQ(vi.Length(), 5);
+  EXPECT_EQ(vi.SquaredLength(), 25);
 }
 

--- a/src/Vector3_TEST.cc
+++ b/src/Vector3_TEST.cc
@@ -143,6 +143,10 @@ TEST(Vector3dTest, Distance)
 
   double dist2 = vec1.Distance(1, 2, 3);
   EXPECT_DOUBLE_EQ(dist, dist2);
+
+  math::Vector3i vecInt(0, 0, 0);
+  int distInt = vec1.Distance({2, 2, 1});
+  EXPECT_EQ(distInt, 3);
 }
 
 /////////////////////////////////////////////////

--- a/src/Vector3_TEST.cc
+++ b/src/Vector3_TEST.cc
@@ -145,7 +145,7 @@ TEST(Vector3dTest, Distance)
   EXPECT_DOUBLE_EQ(dist, dist2);
 
   math::Vector3i vecInt(0, 0, 0);
-  int distInt = vec1.Distance({2, 2, 1});
+  int distInt = vecInt.Distance({2, 2, 1});
   EXPECT_EQ(distInt, 3);
 }
 

--- a/src/Vector3_TEST.cc
+++ b/src/Vector3_TEST.cc
@@ -163,12 +163,15 @@ TEST(Vector3dTest, SquaredLength)
 {
   math::Vector3d vec1(0, 0, 0);
   math::Vector3d vec2(1, 2, 3);
+  math::Vector3i vec3(1, 2, 3);
 
   double sum1 = vec1.SquaredLength();
   double sum2 = vec2.SquaredLength();
+  int sum3 = vec3.SquaredLength();
 
   EXPECT_DOUBLE_EQ(sum1, 0);
   EXPECT_DOUBLE_EQ(sum2, 14);
+  EXPECT_EQ(sum3, 14);
 }
 
 /////////////////////////////////////////////////
@@ -194,6 +197,11 @@ TEST(Vector3dTest, Length)
   math::Vector3d v(0.1, -4.2, 2.5);
   EXPECT_NEAR(v.Length(), 4.88876262463, 1e-10);
   EXPECT_DOUBLE_EQ(v.SquaredLength(), 23.9);
+
+  // Integer vector
+  math::Vector3i vi(1, 2, 2);
+  EXPECT_EQ(vi.Length(), 3);
+  EXPECT_EQ(vi.SquaredLength(), 9);
 }
 
 /////////////////////////////////////////////////

--- a/src/Vector4_TEST.cc
+++ b/src/Vector4_TEST.cc
@@ -420,5 +420,9 @@ TEST(Vector4dTest, Length)
   math::Vector4d v(0.1, -4.2, 2.5, 1.0);
   EXPECT_NEAR(v.Length(), 4.98998997995, 1e-10);
   EXPECT_DOUBLE_EQ(v.SquaredLength(), 24.9);
+
+  // Integer vector
+  EXPECT_EQ(math::Vector4i::One.Length(), 2);
+  EXPECT_EQ(math::Vector4i::One.SquaredLength(), 4);
 }
 

--- a/src/Vector4_TEST.cc
+++ b/src/Vector4_TEST.cc
@@ -268,6 +268,23 @@ TEST(Vector4dTest, EqualTolerance)
 }
 
 /////////////////////////////////////////////////
+TEST(Vector4dTest, Distance)
+{
+  math::Vector4d vec1(0, 0, 0, 0);
+  math::Vector4d vec2(1, 2, 3, 4);
+
+  double dist = vec1.Distance(vec2);
+  EXPECT_NEAR(dist, 5.477225, 1e-6);
+
+  double dist2 = vec1.Distance(1, 2, 3, 4);
+  EXPECT_DOUBLE_EQ(dist, dist2);
+
+  math::Vector4i vecInt(0, 0, 0, 0);
+  int distInt = vec1.Distance({1, 1, 1, 1});
+  EXPECT_EQ(distInt, 2);
+}
+
+/////////////////////////////////////////////////
 TEST(Vector4dTest, Sum)
 {
   math::Vector4d vec1(1.5, 2.5, 3.5, -4.5);

--- a/src/Vector4_TEST.cc
+++ b/src/Vector4_TEST.cc
@@ -280,7 +280,7 @@ TEST(Vector4dTest, Distance)
   EXPECT_DOUBLE_EQ(dist, dist2);
 
   math::Vector4i vecInt(0, 0, 0, 0);
-  int distInt = vec1.Distance({1, 1, 1, 1});
+  int distInt = vecInt.Distance({1, 1, 1, 1});
   EXPECT_EQ(distInt, 2);
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

`ign-gazebo` has the following Windows warning tracing back to `ign-math`:

```
[283.328s] C:\Jenkins\workspace\ign_gazebo-pr-win\ws\install\ignition-math6\include\ignition\math6\ignition/math/Vector2.hh(98,14): warning C4244: 'return': conversion from 'double' to 'T', possible loss of data [C:\Jenkins\workspace\ign_gazebo-pr-win\ws\build\ignition-gazebo5\src\gui\plugins\scene3d\GzScene3D.vcxproj]
```

We don't have lots of tests using integers as templates, so we didn't catch that here. It would be interesting to add tests for that.

I noticed other uses of `std::pow` in the codebase in classes like `Inertial`, `MassMatrix3`, `Sphere`, etc. Some of them don't have integer typedefs (i.e. there's no `Inertiali`), but some of them do (`Spherei`). I'm not sure we have valid use cases for integer shapes, so I didn't add tests for them or updated the `std::pow` usage for now.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

https://github.com/osrf/buildfarmer/issues/181