### PR TITLE
Clean up a few SWIG-related warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,8 +43,6 @@ endif()
 # $ export RUBYLIB=/usr/local/lib/ruby
 # $ ruby -e "require 'ignition/math'; a = Ignition::Math::Angle.new(20); puts a.Degree()"
 if (RUBY_FOUND)
-  include_directories(${RUBY_INCLUDE_DIRS})
-
   foreach (swig_file ${swig_files})
     # Assuming that each swig file has a test
     list(APPEND ruby_tests ${swig_file}_TEST)
@@ -70,6 +68,7 @@ if (RUBY_FOUND)
     $<$<CXX_COMPILER_ID:Clang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
     $<$<CXX_COMPILER_ID:AppleClang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
   )
+  target_include_directories(math SYSTEM PUBLIC ${RUBY_INCLUDE_DIRS})
 
   SWIG_LINK_LIBRARIES(math ${RUBY_LIBRARY})
   target_compile_features(math PUBLIC ${IGN_CXX_${c++standard}_FEATURES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,7 @@ if (RUBY_FOUND)
 
   # Suppress warnings on SWIG-generated files
   target_compile_options(math PRIVATE 
-    $<$<CXX_COMPILER_ID:GNU>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-pedantic -Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
     $<$<CXX_COMPILER_ID:Clang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
     $<$<CXX_COMPILER_ID:AppleClang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,13 @@ add_subdirectory(graph)
 #################################################
 # Setup swig
 if (SWIG_FOUND)
+  if (POLICY CMP0078)
+    cmake_policy(SET CMP0078 NEW)
+  endif()
+  if (POLICY CMP0086)
+    cmake_policy(SET CMP0086 NEW)
+  endif()
+
   include(${SWIG_USE_FILE})
   set(CMAKE_SWIG_FLAGS "")
 
@@ -44,10 +51,6 @@ if (RUBY_FOUND)
 
     # Generate the list if .i files
     list(APPEND swig_i_files ${swig_file}.i)
-
-    # Removing warning from auto-generated files.
-    set_source_files_properties(${swig_file}RUBY_wrap.cxx
-      PROPERTIES COMPILE_FLAGS "-w")
   endforeach()
 
   # Turn on c++
@@ -60,6 +63,13 @@ if (RUBY_FOUND)
   else()
     SWIG_ADD_MODULE(math ruby ruby.i ${swig_i_files} ${sources})
   endif()
+
+  # Suppress warnings on SWIG-generated files
+  target_compile_options(math PRIVATE 
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
+    $<$<CXX_COMPILER_ID:Clang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
+    $<$<CXX_COMPILER_ID:AppleClang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
+  )
 
   SWIG_LINK_LIBRARIES(math ${RUBY_LIBRARY})
   target_compile_features(math PUBLIC ${IGN_CXX_${c++standard}_FEATURES})


### PR DESCRIPTION
* Set policies when relevant
* Suppress warnings on SWIG-generated files

Signed-off-by: Michael Carroll <michael@openrobotics.org>