### PR TITLE
Port to new codecov configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Compile and test
         id: ci
-        uses: ignition-tooling/action-ignition-ci@codecov_token_refactor
+        uses: ignition-tooling/action-ignition-ci@bionic
         with:
           codecov-enabled: true
   focal-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Compile and test
         id: ci
-        uses: ignition-tooling/action-ignition-ci@bionic
+        uses: ignition-tooling/action-ignition-ci@codecov_token_refactor
         with:
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          codecov-enabled: true
   focal-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Focal CI


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The PR changes the codecov management to the one proposed in https://github.com/ignition-tooling/action-ignition-ci/pull/32. Should server as a testing case.

## Checklist
- [x] Signed all commits for DCO

**Note to maintainers**: Remember to use **Squash-Merge**
