### PR TITLE
SWIG Python compilation with CMake >= 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if (NOT SWIG_FOUND)
   IGN_BUILD_WARNING("Swig is missing: Language interfaces are disabled.")
   message (STATUS "Searching for swig - not found.")
 else()
-  message (STATUS "Searching for swig - found.")
+  message (STATUS "Searching for swig - found version ${SWIG_VERSION}.")
 endif()
 
 # Include other languages if swig was found
@@ -55,7 +55,7 @@ if (SWIG_FOUND)
     IGN_BUILD_WARNING("Ruby is missing: Install ruby-dev to enable ruby interface to ignition math.")
     message (STATUS "Searching for Ruby - not found.")
   else()
-    message (STATUS "Searching for Ruby - found.")
+    message (STATUS "Searching for Ruby - found version ${RUBY_VERSION}.")
   endif()
 
   ########################################
@@ -64,7 +64,7 @@ if (SWIG_FOUND)
   if (NOT PYTHONLIBS_FOUND)
     message (STATUS "Searching for Python - not found.")
   else()
-    message (STATUS "Searching for Python - found.")
+    message (STATUS "Searching for Python - found version ${PYTHONLIBS_VERSION_STRING}.")
   endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ add_subdirectory(graph)
 # Setup swig
 if (SWIG_FOUND)
   if (POLICY CMP0078)
-    cmake_policy(SET CMP0078 OLD)
+    cmake_policy(SET CMP0078 NEW)
   endif()
   if (POLICY CMP0086)
     cmake_policy(SET CMP0086 NEW)
@@ -110,12 +110,7 @@ if (PYTHONLIBS_FOUND)
     ignition-math${PROJECT_VERSION_MAJOR}
   )
 
-  # When using SWIG 3 to build a python interface there is an extra underscore between the name of
-  # the library given to swig_add_library macro and the generated .so
-  if(NOT ${SWIG_VERSION} VERSION_GREATER 4.0.0)
-    set(SWIG_PY_LIB "_${SWIG_PY_LIB}")
-    set(SWIG_PY_LIB_OUTPUT "_${SWIG_PY_LIB_OUTPUT}")
-  endif()
+  set(SWIG_PY_LIB "${SWIG_MODULE_pymath_REAL_NAME}")
 
   set_target_properties(${SWIG_PY_LIB}
     PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,10 +112,10 @@ if (PYTHONLIBS_FOUND)
 
   # When using SWIG 3 to build a python interface there is an extra underscore between the name of
   # the library given to swig_add_library macro and the generated .so
-  if(NOT ${SWIG_VERSION} VERSION_GREATER 4.0.0)
-    set(SWIG_PY_LIB "_${SWIG_PY_LIB}")
-    set(SWIG_PY_LIB_OUTPUT "_${SWIG_PY_LIB_OUTPUT}")
-  endif()
+  #if(NOT ${SWIG_VERSION} VERSION_GREATER 4.0.0)
+  #  set(SWIG_PY_LIB "_${SWIG_PY_LIB}")
+  #  set(SWIG_PY_LIB_OUTPUT "_${SWIG_PY_LIB_OUTPUT}")
+  #endif()
 
   set_target_properties(${SWIG_PY_LIB}
     PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,7 @@ if (PYTHONLIBS_FOUND)
   set_source_files_properties(python/python.i PROPERTIES SWIG_FLAGS "-includeall")
   set_source_files_properties(python/python.i PROPERTIES SWIG_MODULE_NAME "math")
   set(SWIG_PY_LIB pymath)
+  set(SWIG_PY_LIB_OUTPUT math)
 
   set(CMAKE_SWIG_OUTDIR "${CMAKE_BINARY_DIR}/lib/python")
   if(CMAKE_VERSION VERSION_GREATER 3.8.0)
@@ -109,7 +110,15 @@ if (PYTHONLIBS_FOUND)
     ignition-math${PROJECT_VERSION_MAJOR}
   )
 
-  set(SWIG_PY_LIB "${SWIG_MODULE_pymath_REAL_NAME}")
+  if(NOT CMAKE_VERSION VERSION_GREATER_EQUAL 3.13.0)
+    set(SWIG_PY_LIB "_${SWIG_PY_LIB}")
+    set(SWIG_PY_LIB_OUTPUT "_${SWIG_PY_LIB_OUTPUT}")
+  endif()
+
+  set_target_properties(${SWIG_PY_LIB}
+    PROPERTIES
+      OUTPUT_NAME ${SWIG_PY_LIB_OUTPUT}
+  )
 
   # Suppress warnings on SWIG-generated files
   target_compile_options(${SWIG_PY_LIB} PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ add_subdirectory(graph)
 # Setup swig
 if (SWIG_FOUND)
   if (POLICY CMP0078)
-    cmake_policy(SET CMP0078 NEW)
+    cmake_policy(SET CMP0078 OLD)
   endif()
   if (POLICY CMP0086)
     cmake_policy(SET CMP0086 NEW)
@@ -112,10 +112,10 @@ if (PYTHONLIBS_FOUND)
 
   # When using SWIG 3 to build a python interface there is an extra underscore between the name of
   # the library given to swig_add_library macro and the generated .so
-  #if(NOT ${SWIG_VERSION} VERSION_GREATER 4.0.0)
-  #  set(SWIG_PY_LIB "_${SWIG_PY_LIB}")
-  #  set(SWIG_PY_LIB_OUTPUT "_${SWIG_PY_LIB_OUTPUT}")
-  #endif()
+  if(NOT ${SWIG_VERSION} VERSION_GREATER 4.0.0)
+    set(SWIG_PY_LIB "_${SWIG_PY_LIB}")
+    set(SWIG_PY_LIB_OUTPUT "_${SWIG_PY_LIB_OUTPUT}")
+  endif()
 
   set_target_properties(${SWIG_PY_LIB}
     PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,7 +96,6 @@ if (PYTHONLIBS_FOUND)
   set_source_files_properties(python/python.i PROPERTIES SWIG_FLAGS "-includeall")
   set_source_files_properties(python/python.i PROPERTIES SWIG_MODULE_NAME "math")
   set(SWIG_PY_LIB pymath)
-  set(SWIG_PY_LIB_OUTPUT math)
 
   set(CMAKE_SWIG_OUTDIR "${CMAKE_BINARY_DIR}/lib/python")
   if(CMAKE_VERSION VERSION_GREATER 3.8.0)
@@ -111,11 +110,6 @@ if (PYTHONLIBS_FOUND)
   )
 
   set(SWIG_PY_LIB "${SWIG_MODULE_pymath_REAL_NAME}")
-
-  set_target_properties(${SWIG_PY_LIB}
-    PROPERTIES
-      OUTPUT_NAME ${SWIG_PY_LIB_OUTPUT}
-  )
 
   # Suppress warnings on SWIG-generated files
   target_compile_options(${SWIG_PY_LIB} PRIVATE


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The problem described in https://github.com/ignitionrobotics/ign-math/pull/216#issuecomment-900584411 turns out to be because of my CMake version, which is 3.21.1.

See [UseSWIG](https://cmake.org/cmake/help/latest/module/UseSWIG.html) as reference.

Version combinations that I'm trying to satisfy:

System | SWIG version | CMake version | Python version 
-- | -- | -- | --
Actions Bionic | 3.0.12 | 3.10.2 | 3.6.9
chapulina's Bionic | 3.0.12 | 3.21.1 | 3.6.9
Actions Focal | 4.0.1 | 3.16.3 | 3.8.10


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
