### PR TITLE
Adds python interface to MaterialType and Material.

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -13,14 +13,6 @@ if (SWIG_FOUND)
 
   include_directories(${PROJECT_SOURCE_DIR}/include)
   include_directories(${PYTHON_INCLUDE_PATH})
-
-  set(swig_files
-    Angle
-    GaussMarkovProcess
-    Rand
-    Vector2
-    Vector3
-    Vector4)
 endif()
 
 #################################
@@ -72,6 +64,7 @@ if (PYTHONLIBS_FOUND)
       GaussMarkovProcess_TEST
       Line2_TEST
       Line3_TEST
+      Material_TEST
       python_TEST
       Rand_TEST
       SignalStats_TEST

--- a/src/python/Material.i
+++ b/src/python/Material.i
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+%module material
+%{
+#include <ignition/math/config.hh>
+#include <ignition/math/Export.hh>
+#include <ignition/math/Material.hh>
+#include <ignition/math/MaterialType.hh>
+%}
+
+%include "std_string.i"
+%include "std_map.i"
+%template(map_material_type) std::map<ignition::math::MaterialType,
+                                      ignition::math::Material>;
+
+namespace ignition
+{
+namespace math
+{
+    class Material
+    {
+      %rename("%(undercase)s", %$isfunction, %$ismember, %$not %$isconstructor) "";
+      public: Material();
+      public: explicit Material(const MaterialType _type);
+      public: explicit Material(const std::string &_typename);
+      public: explicit Material(const double _density);
+      public: Material(const Material &_material);
+      public: ~Material();
+      public: static const std::map<MaterialType, Material> &Predefined();
+      public: void SetToNearestDensity(
+                  const double _value,
+                  const double _epsilon = std::numeric_limits<double>::max());
+      public: bool operator==(const Material &_material) const;
+      public: bool operator!=(const Material &_material) const;
+      public: MaterialType Type() const;
+      public: void SetType(const MaterialType _type);
+      public: std::string Name() const;
+      public: void SetName(const std::string &_name);
+      public: double Density() const;
+      public: void SetDensity(const double _density);
+    };
+}
+}

--- a/src/python/MaterialType.i
+++ b/src/python/MaterialType.i
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+%module materialtype
+%{
+#include <ignition/math/config.hh>
+#include <ignition/math/Export.hh>
+#include <ignition/math/MaterialType.hh>
+%}
+
+namespace ignition
+{
+namespace math
+{
+  enum class MaterialType
+    {
+      STYROFOAM = 0,
+      PINE,
+      WOOD,
+      OAK,
+      PLASTIC,
+      CONCRETE,
+      ALUMINUM,
+      STEEL_ALLOY,
+      STEEL_STAINLESS,
+      IRON,
+      BRASS,
+      COPPER,
+      TUNGSTEN,
+      UNKNOWN_MATERIAL
+    };
+}
+}

--- a/src/python/Material_TEST.py
+++ b/src/python/Material_TEST.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2021 Open Source Robotics Foundation
+
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#       http:#www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import ignition.math
+
+
+class TestMaterial(unittest.TestCase):
+
+    def test_init(self):
+        mats = ignition.math.Material.predefined()
+        self.assertFalse(mats.empty())
+
+    def test_comparison(self):
+        aluminum = ignition.math.Material(ignition.math.MaterialType_ALUMINUM)
+
+        modified = ignition.math.Material(aluminum)
+        self.assertEqual(modified, aluminum)
+
+        modified.set_density(1234.0)
+        self.assertNotEqual(modified, aluminum)
+
+        modified = ignition.math.Material(aluminum)
+        self.assertEqual(modified, aluminum)
+
+        modified.set_type(ignition.math.MaterialType_PINE)
+        self.assertNotEqual(modified, aluminum)
+
+    def test_accessors(self):
+
+        mat = ignition.math.Material("Aluminum")
+        mat1 = ignition.math.Material("aluminum")
+        mat2 = ignition.math.Material(ignition.math.MaterialType_ALUMINUM)
+        mat3 = ignition.math.Material(mat2)
+
+        self.assertAlmostEqual(2700.0, mat.density())
+        self.assertEqual(mat, mat1)
+        self.assertEqual(mat1, mat2)
+        self.assertEqual(mat2, mat3)
+
+        # Test constructor
+        mat4 = ignition.math.Material(mat3)
+        self.assertEqual(mat2, mat4)
+
+        mat5 = ignition.math.Material(mat4)
+        self.assertEqual(mat2, mat5)
+
+        mat = ignition.math.Material("Notfoundium")
+        self.assertGreater(0.0, mat.density())
+        self.assertEqual(ignition.math.MaterialType_UNKNOWN_MATERIAL,
+                         mat.type())
+        self.assertFalse(mat.name())
+
+        material = ignition.math.Material()
+        material.set_to_nearest_density(19300.0)
+        self.assertEqual(ignition.math.MaterialType_TUNGSTEN, material.type())
+        self.assertAlmostEqual(19300.0, material.density())
+
+        material = ignition.math.Material()
+        material.set_to_nearest_density(1001001.001, 1e-3)
+        self.assertEqual(ignition.math.MaterialType_UNKNOWN_MATERIAL,
+                         material.type())
+        self.assertGreater(0.0, material.density())
+        material = ignition.math.Material()
+        material.set_to_nearest_density(1001001.001)
+        self.assertEqual(ignition.math.MaterialType_TUNGSTEN, material.type())
+        self.assertAlmostEqual(19300, material.density())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/python/python.i
+++ b/src/python/python.i
@@ -9,3 +9,6 @@
 %include Line3.i
 %include SignalStats.i
 %include Temperature.i
+%include MaterialType.i
+%include Material.i
+


### PR DESCRIPTION
# 🎉 New feature

Related to #101 #210

## Summary
Adds Python interface for three math classes: MaterialType, Material. For each Material a python test has been created.

## Related issues and notes
### MaterialType
This file contains an `enum class` declaration. Swig supports strongly typed enumerations, so binding this wasn't a problem. But the result was a series of variables contained in the module `ignition.math` defined as `MaterialType_MATERIAL`. A work around is needed to be implemented in order to follow the pep-8 naming convention.

### Material
**The test is not passing.**
* This class contains a method `Predefined()` that returns a reference to an `std::map<MaterialType, Material>`.  In  `SignalStats`a map was used as well, so a similar approach was taken for this case. There are two main differences in both of this classes:
   * In `SignalStats` the map is returned as a copy and 
   * the types of the map are `std::string` and `double`. 
  
* In the case of `Material` the method is not being wrapped correctly. Instead of being part of the `Material` class, is defined outside of it, and when it is used in the test as follow:

      mats = ignition.math.Material.predefined() 

   it arises an error:
   ```
   swig/python detected a memory leak of type 'unknown', no destructor found.
      TypeError: unhashable type: 'SwigPyObject'
      The above exception was the direct cause of the following exception:

       Traceback (most recent call last):
        File "/ws/src/ign-math/src/python/Material_TEST.py", line 22, in test_init
           mats = ignition.math.Material.predefined()
       SystemError: <built-in function Material_predefined> returned a result with an error set 


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

