### PR TITLE
🌐 Spherical coordinates: bug fix, docs and sanity checks

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,13 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition Math 6.8 to 6.9
+
+1. **SphericalCoordinates**: A bug related to the LOCAL frame was fixed. To
+   preserve behaviour, the `LOCAL` frame was left with the bug, and a new
+   `LOCAL2` frame was introduced, which can be used to get the correct
+   calculations.
+
 ## Ignition Math 4.X to 5.X
 
 ### Additions

--- a/include/ignition/math/SphericalCoordinates.hh
+++ b/include/ignition/math/SphericalCoordinates.hh
@@ -34,7 +34,6 @@ namespace ignition
     //
     class SphericalCoordinatesPrivate;
 
-    /// \class SphericalCoordinates SphericalCoordinates.hh commmon/common.hh
     /// \brief Convert spherical coordinates for planetary surfaces.
     class IGNITION_MATH_VISIBLE SphericalCoordinates
     {
@@ -61,7 +60,12 @@ namespace ignition
                 GLOBAL = 3,
 
                 /// \brief Heading-adjusted tangent plane (X, Y, Z)
-                LOCAL = 4
+                /// This has kept a bug for backwards compatibility, use
+                /// LOCAL_FIXED for the correct behaviour.
+                LOCAL = 4,
+
+                /// \brief Heading-adjusted tangent plane (X, Y, Z)
+                LOCAL_FIXED = 5
               };
 
       /// \brief Constructor.
@@ -91,7 +95,14 @@ namespace ignition
       public: ~SphericalCoordinates();
 
       /// \brief Convert a Cartesian position vector to geodetic coordinates.
-      /// \param[in] _xyz Cartesian position vector in the world frame.
+      /// This performs a `PositionTransform` from LOCAL to SPHERICAL.
+      ///
+      /// There's a known bug with this computation that can't be fixed on
+      /// version 6 to avoid behaviour changes. Directly call
+      /// `PositionTransform(_xyz, LOCAL_FIXED, SPHERICAL)` for correct results.
+      ///
+      /// \param[in] _xyz Cartesian position vector in the heading-adjusted
+      /// world frame.
       /// \return Cooordinates: geodetic latitude (deg), longitude (deg),
       ///         altitude above sea level (m).
       public: ignition::math::Vector3d SphericalFromLocalPosition(
@@ -99,7 +110,14 @@ namespace ignition
 
       /// \brief Convert a Cartesian velocity vector in the local frame
       ///        to a global Cartesian frame with components East, North, Up.
-      /// \param[in] _xyz Cartesian velocity vector in the world frame.
+      /// This is a wrapper around `VelocityTransform(_xyz, LOCAL, GLOBAL)`
+      ///
+      /// There's a known bug with this computation that can't be fixed on
+      /// version 6 to avoid behaviour changes. Directly call
+      /// `VelocityTransform(_xyz, LOCAL_FIXED, GLOBAL)` for correct results.
+      ///
+      /// \param[in] _xyz Cartesian velocity vector in the heading-adjusted
+      /// world frame.
       /// \return Rotated vector with components (x,y,z): (East, North, Up).
       public: ignition::math::Vector3d GlobalFromLocalVelocity(
                   const ignition::math::Vector3d &_xyz) const;
@@ -167,13 +185,16 @@ namespace ignition
       public: void SetHeadingOffset(const ignition::math::Angle &_angle);
 
       /// \brief Convert a geodetic position vector to Cartesian coordinates.
-      /// \param[in] _xyz Geodetic position in the planetary frame of reference
-      /// \return Cartesian position vector in the world frame
+      /// This performs a `PositionTransform` from SPHERICAL to LOCAL.
+      /// \param[in] _latLonEle Geodetic position in the planetary frame of
+      /// reference. X: latitude (deg), Y: longitude (deg), X: altitude.
+      /// \return Cartesian position vector in the heading-adjusted world frame.
       public: ignition::math::Vector3d LocalFromSphericalPosition(
-                  const ignition::math::Vector3d &_xyz) const;
+                  const ignition::math::Vector3d &_latLonEle) const;
 
       /// \brief Convert a Cartesian velocity vector with components East,
       /// North, Up to a local cartesian frame vector XYZ.
+      /// This is a wrapper around `VelocityTransform(_xyz, GLOBAL, LOCAL)`
       /// \param[in] _xyz Vector with components (x,y,z): (East, North, Up).
       /// \return Cartesian vector in the world frame.
       public: ignition::math::Vector3d LocalFromGlobalVelocity(

--- a/include/ignition/math/SphericalCoordinates.hh
+++ b/include/ignition/math/SphericalCoordinates.hh
@@ -100,6 +100,8 @@ namespace ignition
       /// There's a known bug with this computation that can't be fixed on
       /// version 6 to avoid behaviour changes. Directly call
       /// `PositionTransform(_xyz, LOCAL2, SPHERICAL)` for correct results.
+      /// Note that `PositionTransform` returns spherical coordinates in
+      /// radians.
       ///
       /// \param[in] _xyz Cartesian position vector in the heading-adjusted
       /// world frame.
@@ -209,15 +211,17 @@ namespace ignition
       public: void UpdateTransformationMatrix();
 
       /// \brief Convert between positions in SPHERICAL/ECEF/LOCAL/GLOBAL frame
+      /// Spherical coordinates use radians, while the other frames use meters.
       /// \param[in] _pos Position vector in frame defined by parameter _in
       /// \param[in] _in  CoordinateType for input
       /// \param[in] _out CoordinateType for output
-      /// \return Transformed coordinate using cached orgin
+      /// \return Transformed coordinate using cached origin.
       public: ignition::math::Vector3d
               PositionTransform(const ignition::math::Vector3d &_pos,
                   const CoordinateType &_in, const CoordinateType &_out) const;
 
       /// \brief Convert between velocity in SPHERICAL/ECEF/LOCAL/GLOBAL frame
+      /// Spherical coordinates use radians, while the other frames use meters.
       /// \param[in] _vel Velocity vector in frame defined by parameter _in
       /// \param[in] _in  CoordinateType for input
       /// \param[in] _out CoordinateType for output

--- a/include/ignition/math/SphericalCoordinates.hh
+++ b/include/ignition/math/SphericalCoordinates.hh
@@ -128,6 +128,11 @@ namespace ignition
       /// \return Conversion to SurfaceType.
       public: static SurfaceType Convert(const std::string &_str);
 
+      /// \brief Convert a SurfaceType to a string.
+      /// \param[in] _type Surface type
+      /// \return Type as string
+      public: static std::string Convert(SurfaceType _type);
+
       /// \brief Get the distance between two points expressed in geographic
       /// latitude and longitude. It assumes that both points are at sea level.
       /// Example: _latA = 38.0016667 and _lonA = -123.0016667) represents

--- a/include/ignition/math/SphericalCoordinates.hh
+++ b/include/ignition/math/SphericalCoordinates.hh
@@ -61,11 +61,11 @@ namespace ignition
 
                 /// \brief Heading-adjusted tangent plane (X, Y, Z)
                 /// This has kept a bug for backwards compatibility, use
-                /// LOCAL_FIXED for the correct behaviour.
+                /// LOCAL2 for the correct behaviour.
                 LOCAL = 4,
 
                 /// \brief Heading-adjusted tangent plane (X, Y, Z)
-                LOCAL_FIXED = 5
+                LOCAL2 = 5
               };
 
       /// \brief Constructor.
@@ -99,7 +99,7 @@ namespace ignition
       ///
       /// There's a known bug with this computation that can't be fixed on
       /// version 6 to avoid behaviour changes. Directly call
-      /// `PositionTransform(_xyz, LOCAL_FIXED, SPHERICAL)` for correct results.
+      /// `PositionTransform(_xyz, LOCAL2, SPHERICAL)` for correct results.
       ///
       /// \param[in] _xyz Cartesian position vector in the heading-adjusted
       /// world frame.
@@ -114,7 +114,7 @@ namespace ignition
       ///
       /// There's a known bug with this computation that can't be fixed on
       /// version 6 to avoid behaviour changes. Directly call
-      /// `VelocityTransform(_xyz, LOCAL_FIXED, GLOBAL)` for correct results.
+      /// `VelocityTransform(_xyz, LOCAL2, GLOBAL)` for correct results.
       ///
       /// \param[in] _xyz Cartesian velocity vector in the heading-adjusted
       /// world frame.

--- a/src/SphericalCoordinates.cc
+++ b/src/SphericalCoordinates.cc
@@ -372,8 +372,19 @@ ignition::math::Vector3d SphericalCoordinates::PositionTransform(
             this->dataPtr->sinHea);
         tmp.Y(-_pos.X() * this->dataPtr->sinHea - _pos.Y() *
             this->dataPtr->cosHea);
+        tmp = this->dataPtr->origin + this->dataPtr->rotGlobalToECEF * tmp;
+        break;
       }
-      /* Falls through. */
+
+    case LOCAL_FIXED:
+      {
+        tmp.X(_pos.X() * this->dataPtr->cosHea + _pos.Y() *
+            this->dataPtr->sinHea);
+        tmp.Y(-_pos.X() * this->dataPtr->sinHea + _pos.Y() *
+            this->dataPtr->cosHea);
+        tmp = this->dataPtr->origin + this->dataPtr->rotGlobalToECEF * tmp;
+        break;
+      }
 
     case GLOBAL:
       {
@@ -440,6 +451,7 @@ ignition::math::Vector3d SphericalCoordinates::PositionTransform(
 
     // Convert from ECEF TO LOCAL
     case LOCAL:
+    case LOCAL_FIXED:
       tmp = this->dataPtr->rotECEFToGlobal * (tmp - this->dataPtr->origin);
 
       tmp = ignition::math::Vector3d(
@@ -477,13 +489,21 @@ ignition::math::Vector3d SphericalCoordinates::VelocityTransform(
   // First, convert to an ECEF vector
   switch (_in)
   {
-    // ENU (note no break at end of case)
+    // ENU
     case LOCAL:
       tmp.X(-_vel.X() * this->dataPtr->cosHea + _vel.Y() *
             this->dataPtr->sinHea);
       tmp.Y(-_vel.X() * this->dataPtr->sinHea - _vel.Y() *
             this->dataPtr->cosHea);
-      /* Falls through. */
+      tmp = this->dataPtr->rotGlobalToECEF * tmp;
+      break;
+    case LOCAL_FIXED:
+      tmp.X(_vel.X() * this->dataPtr->cosHea + _vel.Y() *
+            this->dataPtr->sinHea);
+      tmp.Y(-_vel.X() * this->dataPtr->sinHea + _vel.Y() *
+            this->dataPtr->cosHea);
+      tmp = this->dataPtr->rotGlobalToECEF * tmp;
+      break;
     // spherical
     case GLOBAL:
       tmp = this->dataPtr->rotGlobalToECEF * tmp;
@@ -511,6 +531,7 @@ ignition::math::Vector3d SphericalCoordinates::VelocityTransform(
 
     // Convert from ECEF to local
     case LOCAL:
+    case LOCAL_FIXED:
       tmp = this->dataPtr->rotECEFToGlobal * tmp;
       tmp = ignition::math::Vector3d(
           tmp.X() * this->dataPtr->cosHea - tmp.Y() * this->dataPtr->sinHea,

--- a/src/SphericalCoordinates.cc
+++ b/src/SphericalCoordinates.cc
@@ -100,6 +100,18 @@ SphericalCoordinates::SurfaceType SphericalCoordinates::Convert(
 }
 
 //////////////////////////////////////////////////
+std::string SphericalCoordinates::Convert(
+    SphericalCoordinates::SurfaceType _type)
+{
+  if (EARTH_WGS84)
+    return "EARTH_WGS84";
+
+  std::cerr << "SurfaceType not recognized, "
+    << "EARTH_WGS84 returned by default" << std::endl;
+  return "EARTH_WGS84";
+}
+
+//////////////////////////////////////////////////
 SphericalCoordinates::SphericalCoordinates()
   : dataPtr(new SphericalCoordinatesPrivate)
 {

--- a/src/SphericalCoordinates.cc
+++ b/src/SphericalCoordinates.cc
@@ -376,7 +376,7 @@ ignition::math::Vector3d SphericalCoordinates::PositionTransform(
         break;
       }
 
-    case LOCAL_FIXED:
+    case LOCAL2:
       {
         tmp.X(_pos.X() * this->dataPtr->cosHea + _pos.Y() *
             this->dataPtr->sinHea);
@@ -451,7 +451,7 @@ ignition::math::Vector3d SphericalCoordinates::PositionTransform(
 
     // Convert from ECEF TO LOCAL
     case LOCAL:
-    case LOCAL_FIXED:
+    case LOCAL2:
       tmp = this->dataPtr->rotECEFToGlobal * (tmp - this->dataPtr->origin);
 
       tmp = ignition::math::Vector3d(
@@ -497,7 +497,7 @@ ignition::math::Vector3d SphericalCoordinates::VelocityTransform(
             this->dataPtr->cosHea);
       tmp = this->dataPtr->rotGlobalToECEF * tmp;
       break;
-    case LOCAL_FIXED:
+    case LOCAL2:
       tmp.X(_vel.X() * this->dataPtr->cosHea + _vel.Y() *
             this->dataPtr->sinHea);
       tmp.Y(-_vel.X() * this->dataPtr->sinHea + _vel.Y() *
@@ -531,7 +531,7 @@ ignition::math::Vector3d SphericalCoordinates::VelocityTransform(
 
     // Convert from ECEF to local
     case LOCAL:
-    case LOCAL_FIXED:
+    case LOCAL2:
       tmp = this->dataPtr->rotECEFToGlobal * tmp;
       tmp = ignition::math::Vector3d(
           tmp.X() * this->dataPtr->cosHea - tmp.Y() * this->dataPtr->sinHea,

--- a/src/SphericalCoordinates.cc
+++ b/src/SphericalCoordinates.cc
@@ -103,7 +103,7 @@ SphericalCoordinates::SurfaceType SphericalCoordinates::Convert(
 std::string SphericalCoordinates::Convert(
     SphericalCoordinates::SurfaceType _type)
 {
-  if (EARTH_WGS84)
+  if (_type == EARTH_WGS84)
     return "EARTH_WGS84";
 
   std::cerr << "SurfaceType not recognized, "

--- a/src/SphericalCoordinates_TEST.cc
+++ b/src/SphericalCoordinates_TEST.cc
@@ -441,7 +441,7 @@ TEST(SphericalCoordinatesTest, NoHeading)
   math::SphericalCoordinates sc(st, lat, lon, elev, heading);
 
   // Origin matches input
-  auto latLonAlt = sc.SphericalFromLocalPosition({0,0,0});
+  auto latLonAlt = sc.SphericalFromLocalPosition({0, 0, 0});
   EXPECT_DOUBLE_EQ(lat.Degree(), latLonAlt.X());
   EXPECT_DOUBLE_EQ(lon.Degree(), latLonAlt.Y());
   EXPECT_DOUBLE_EQ(elev, latLonAlt.Z());
@@ -519,7 +519,7 @@ TEST(SphericalCoordinatesTest, WithHeading)
   math::SphericalCoordinates sc(st, lat, lon, elev, IGN_DTOR(90));
 
   // Origin matches input
-  auto latLonAlt = sc.SphericalFromLocalPosition({0,0,0});
+  auto latLonAlt = sc.SphericalFromLocalPosition({0, 0, 0});
   EXPECT_DOUBLE_EQ(lat.Degree(), latLonAlt.X());
   EXPECT_DOUBLE_EQ(lon.Degree(), latLonAlt.Y());
   EXPECT_DOUBLE_EQ(elev, latLonAlt.Z());
@@ -573,7 +573,7 @@ TEST(SphericalCoordinatesTest, WithHeading)
       {{math::Vector3d::UnitX, -math::Vector3d::UnitY},
       {-math::Vector3d::UnitX, math::Vector3d::UnitY},
       {math::Vector3d::UnitY, math::Vector3d::UnitX},
-      {-math::Vector3d::UnitY,-math::Vector3d::UnitX}};
+      {-math::Vector3d::UnitY, -math::Vector3d::UnitX}};
   for (auto [global, local] : globalLocal)
   {
     auto localRes = sc.LocalFromGlobalVelocity(global);

--- a/src/SphericalCoordinates_TEST.cc
+++ b/src/SphericalCoordinates_TEST.cc
@@ -77,6 +77,10 @@ TEST(SphericalCoordinatesTest, Convert)
 
   EXPECT_EQ(math::SphericalCoordinates::EARTH_WGS84,
             math::SphericalCoordinates::Convert("OTHER-COORD"));
+
+  EXPECT_EQ("EARTH_WGS84", math::SphericalCoordinates::Convert(st));
+  EXPECT_EQ("EARTH_WGS84", math::SphericalCoordinates::Convert(
+      static_cast<math::SphericalCoordinates::SurfaceType>(2)));
 }
 
 //////////////////////////////////////////////////

--- a/src/SphericalCoordinates_TEST.cc
+++ b/src/SphericalCoordinates_TEST.cc
@@ -128,6 +128,8 @@ TEST(SphericalCoordinatesTest, CoordinateTransforms)
     math::SphericalCoordinates sc(st, lat, lon, elev, heading);
 
     // Check GlobalFromLocal with heading offset of 90 degrees
+    // Heading 0:  X == East, Y == North, Z == Up
+    // Heading 90: X == North, Y == West , Z == Up
     {
       // local frame
       ignition::math::Vector3d xyz;
@@ -136,8 +138,8 @@ TEST(SphericalCoordinatesTest, CoordinateTransforms)
 
       xyz.Set(1, 0, 0);
       enu = sc.GlobalFromLocalVelocity(xyz);
-      EXPECT_NEAR(enu.Y(), xyz.X(), 1e-6);
-      EXPECT_NEAR(enu.X(), -xyz.Y(), 1e-6);
+      EXPECT_NEAR(enu.Y()/*North*/, xyz.X(), 1e-6);
+      EXPECT_NEAR(enu.X()/*East*/, -xyz.Y(), 1e-6);
       EXPECT_EQ(xyz, sc.LocalFromGlobalVelocity(enu));
 
       xyz.Set(0, 1, 0);
@@ -253,6 +255,49 @@ TEST(SphericalCoordinatesTest, CoordinateTransforms)
       EXPECT_NEAR(tmp.Z(), goog_s.Z(), 1e-2);
     }
   }
+
+  // Give no heading offset to confirm ENU frame
+  {
+    ignition::math::Angle lat(0.3), lon(-1.2), heading(0.0);
+    double elev = 354.1;
+    math::SphericalCoordinates sc(st, lat, lon, elev, heading);
+
+    // Check GlobalFromLocal with no heading offset
+    {
+      // local frame
+      ignition::math::Vector3d xyz;
+      // east, north, up
+      ignition::math::Vector3d enu;
+
+      xyz.Set(1, 0, 0);
+      enu = sc.VelocityTransform(xyz,
+        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::GLOBAL);
+      EXPECT_EQ(xyz, enu);
+      EXPECT_EQ(xyz, sc.LocalFromGlobalVelocity(enu));
+
+      xyz.Set(0, 1, 0);
+      enu = sc.VelocityTransform(xyz,
+        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::GLOBAL);
+      EXPECT_EQ(xyz, enu);
+      EXPECT_EQ(xyz, sc.LocalFromGlobalVelocity(enu));
+
+      xyz.Set(1, -1, 0);
+      enu = sc.VelocityTransform(xyz,
+        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::GLOBAL);
+      EXPECT_EQ(xyz, enu);
+      EXPECT_EQ(xyz, sc.LocalFromGlobalVelocity(enu));
+
+      xyz.Set(2243.52334, 556.35, 435.6553);
+      enu = sc.VelocityTransform(xyz,
+        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::GLOBAL);
+      EXPECT_EQ(xyz, enu);
+      EXPECT_EQ(xyz, sc.LocalFromGlobalVelocity(enu));
+    }
+  }
 }
 
 //////////////////////////////////////////////////
@@ -306,7 +351,7 @@ TEST(SphericalCoordinatesTest, BadCoordinateType)
   math::SphericalCoordinates sc;
   math::Vector3d pos(1, 2, -4);
   math::Vector3d result = sc.PositionTransform(pos,
-      static_cast<math::SphericalCoordinates::CoordinateType>(5),
+      static_cast<math::SphericalCoordinates::CoordinateType>(7),
       static_cast<math::SphericalCoordinates::CoordinateType>(6));
 
   EXPECT_EQ(result, pos);
@@ -328,13 +373,13 @@ TEST(SphericalCoordinatesTest, BadCoordinateType)
   EXPECT_EQ(result, pos);
 
   result = sc.VelocityTransform(pos,
-      static_cast<math::SphericalCoordinates::CoordinateType>(5),
+      static_cast<math::SphericalCoordinates::CoordinateType>(7),
       math::SphericalCoordinates::ECEF);
   EXPECT_EQ(result, pos);
 
   result = sc.VelocityTransform(pos,
       math::SphericalCoordinates::ECEF,
-      static_cast<math::SphericalCoordinates::CoordinateType>(5));
+      static_cast<math::SphericalCoordinates::CoordinateType>(7));
   EXPECT_EQ(result, pos);
 }
 
@@ -382,4 +427,162 @@ TEST(SphericalCoordinatesTest, AssignmentOp)
 
   math::SphericalCoordinates sc2 = sc1;
   EXPECT_EQ(sc1, sc2);
+}
+
+//////////////////////////////////////////////////
+TEST(SphericalCoordinatesTest, NoHeading)
+{
+  // Default heading
+  auto st = math::SphericalCoordinates::EARTH_WGS84;
+  math::Angle lat(IGN_DTOR(-22.9));
+  math::Angle lon(IGN_DTOR(-43.2));
+  math::Angle heading(0.0);
+  double elev = 0;
+  math::SphericalCoordinates sc(st, lat, lon, elev, heading);
+
+  // Origin matches input
+  auto latLonAlt = sc.SphericalFromLocalPosition({0,0,0});
+  EXPECT_DOUBLE_EQ(lat.Degree(), latLonAlt.X());
+  EXPECT_DOUBLE_EQ(lon.Degree(), latLonAlt.Y());
+  EXPECT_DOUBLE_EQ(elev, latLonAlt.Z());
+
+  auto xyzOrigin = sc.LocalFromSphericalPosition(latLonAlt);
+  EXPECT_EQ(math::Vector3d::Zero, xyzOrigin);
+
+  // Check how different lat/lon affect the local position
+
+  // Increase latitude == go North == go +Y
+  {
+    auto xyz = sc.LocalFromSphericalPosition(
+        {lat.Degree() + 1.0, lon.Degree(), elev});
+    EXPECT_NEAR(xyzOrigin.X(), xyz.X(), 1e-6);
+    EXPECT_LT(xyzOrigin.Y(), xyz.Y());
+  }
+
+  // Decrease latitude == go South == go -Y
+  {
+    auto xyz = sc.LocalFromSphericalPosition(
+        {lat.Degree() - 1.0, lon.Degree(), elev});
+    EXPECT_NEAR(xyzOrigin.X(), xyz.X(), 1e-6);
+    EXPECT_GT(xyzOrigin.Y(), xyz.Y());
+  }
+
+  // Increase longitude == go East == go +X (and a bit -Y)
+  {
+    auto xyz = sc.LocalFromSphericalPosition(
+        {lat.Degree(), lon.Degree() + 1.0, elev});
+    EXPECT_LT(xyzOrigin.X(), xyz.X());
+    EXPECT_GT(xyzOrigin.Y(), xyz.Y());
+  }
+
+  // Decrease longitude == go West == go -X (and a bit -Y)
+  {
+    auto xyz = sc.LocalFromSphericalPosition(
+        {lat.Degree(), lon.Degree() - 1.0, elev});
+    EXPECT_GT(xyzOrigin.X(), xyz.X());
+    EXPECT_GT(xyzOrigin.Y(), xyz.Y());
+  }
+
+  // Check how global and local velocities are connected
+
+  // Velocity in +X (East), +Y (North), -X (West), -Y (South)
+  for (auto global : {
+      math::Vector3d::UnitX,
+      math::Vector3d::UnitY,
+      -math::Vector3d::UnitX,
+      -math::Vector3d::UnitY})
+  {
+    auto local = sc.LocalFromGlobalVelocity(global);
+    EXPECT_EQ(global, local);
+
+    // This function is broken
+    global = sc.GlobalFromLocalVelocity(local);
+    EXPECT_NE(global, local);
+
+    // Directly call fixed version
+    global = sc.VelocityTransform(local,
+        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::GLOBAL);
+    EXPECT_EQ(global, local);
+  }
+}
+
+//////////////////////////////////////////////////
+TEST(SphericalCoordinatesTest, WithHeading)
+{
+  // Heading 90 deg: X == North, Y == West , Z == Up
+  auto st = math::SphericalCoordinates::EARTH_WGS84;
+  math::Angle lat(IGN_DTOR(-22.9));
+  math::Angle lon(IGN_DTOR(-43.2));
+  math::Angle heading(0.0);
+  double elev = 0;
+  math::SphericalCoordinates sc(st, lat, lon, elev, IGN_DTOR(90));
+
+  // Origin matches input
+  auto latLonAlt = sc.SphericalFromLocalPosition({0,0,0});
+  EXPECT_DOUBLE_EQ(lat.Degree(), latLonAlt.X());
+  EXPECT_DOUBLE_EQ(lon.Degree(), latLonAlt.Y());
+  EXPECT_DOUBLE_EQ(elev, latLonAlt.Z());
+
+  auto xyzOrigin = sc.LocalFromSphericalPosition(latLonAlt);
+  EXPECT_EQ(math::Vector3d::Zero, xyzOrigin);
+
+  // Check how different lat/lon affect the local position
+
+  // Increase latitude == go North == go +X
+  {
+    auto xyz = sc.LocalFromSphericalPosition(
+        {lat.Degree() + 1.0, lon.Degree(), elev});
+    EXPECT_NEAR(xyzOrigin.Y(), xyz.Y(), 1e-6);
+    EXPECT_LT(xyzOrigin.X(), xyz.X());
+  }
+
+  // Decrease latitude == go South == go -X
+  {
+    auto xyz = sc.LocalFromSphericalPosition(
+        {lat.Degree() - 1.0, lon.Degree(), elev});
+    EXPECT_NEAR(xyzOrigin.Y(), xyz.Y(), 1e-6);
+    EXPECT_GT(xyzOrigin.X(), xyz.X());
+  }
+
+  // Increase longitude == go East == go -Y (and a bit -X)
+  {
+    auto xyz = sc.LocalFromSphericalPosition(
+        {lat.Degree(), lon.Degree() + 1.0, elev});
+    EXPECT_GT(xyzOrigin.Y(), xyz.Y());
+    EXPECT_GT(xyzOrigin.X(), xyz.X());
+  }
+
+  // Decrease longitude == go West == go +Y (and a bit -X)
+  {
+    auto xyz = sc.LocalFromSphericalPosition(
+        {lat.Degree(), lon.Degree() - 1.0, elev});
+    EXPECT_LT(xyzOrigin.Y(), xyz.Y());
+    EXPECT_GT(xyzOrigin.X(), xyz.X());
+  }
+
+  // Check how global and local velocities are connected
+
+  // Global     | Local
+  // ---------- | ------
+  // +X (East)  | -Y
+  // -X (West)  | +Y
+  // +Y (North) | +X
+  // -Y (South) | -X
+  std::vector<std::pair<math::Vector3d, math::Vector3d>> globalLocal =
+      {{math::Vector3d::UnitX, -math::Vector3d::UnitY},
+      {-math::Vector3d::UnitX, math::Vector3d::UnitY},
+      {math::Vector3d::UnitY, math::Vector3d::UnitX},
+      {-math::Vector3d::UnitY,-math::Vector3d::UnitX}};
+  for (auto [global, local] : globalLocal)
+  {
+    auto localRes = sc.LocalFromGlobalVelocity(global);
+    EXPECT_EQ(local, localRes);
+
+    // Directly call fixed version
+    auto globalRes = sc.VelocityTransform(local,
+        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::GLOBAL);
+    EXPECT_EQ(global, globalRes);
+  }
 }

--- a/src/SphericalCoordinates_TEST.cc
+++ b/src/SphericalCoordinates_TEST.cc
@@ -271,28 +271,28 @@ TEST(SphericalCoordinatesTest, CoordinateTransforms)
 
       xyz.Set(1, 0, 0);
       enu = sc.VelocityTransform(xyz,
-        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::LOCAL2,
         math::SphericalCoordinates::GLOBAL);
       EXPECT_EQ(xyz, enu);
       EXPECT_EQ(xyz, sc.LocalFromGlobalVelocity(enu));
 
       xyz.Set(0, 1, 0);
       enu = sc.VelocityTransform(xyz,
-        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::LOCAL2,
         math::SphericalCoordinates::GLOBAL);
       EXPECT_EQ(xyz, enu);
       EXPECT_EQ(xyz, sc.LocalFromGlobalVelocity(enu));
 
       xyz.Set(1, -1, 0);
       enu = sc.VelocityTransform(xyz,
-        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::LOCAL2,
         math::SphericalCoordinates::GLOBAL);
       EXPECT_EQ(xyz, enu);
       EXPECT_EQ(xyz, sc.LocalFromGlobalVelocity(enu));
 
       xyz.Set(2243.52334, 556.35, 435.6553);
       enu = sc.VelocityTransform(xyz,
-        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::LOCAL2,
         math::SphericalCoordinates::GLOBAL);
       EXPECT_EQ(xyz, enu);
       EXPECT_EQ(xyz, sc.LocalFromGlobalVelocity(enu));
@@ -501,7 +501,7 @@ TEST(SphericalCoordinatesTest, NoHeading)
 
     // Directly call fixed version
     global = sc.VelocityTransform(local,
-        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::LOCAL2,
         math::SphericalCoordinates::GLOBAL);
     EXPECT_EQ(global, local);
   }
@@ -581,7 +581,7 @@ TEST(SphericalCoordinatesTest, WithHeading)
 
     // Directly call fixed version
     auto globalRes = sc.VelocityTransform(local,
-        math::SphericalCoordinates::LOCAL_FIXED,
+        math::SphericalCoordinates::LOCAL2,
         math::SphericalCoordinates::GLOBAL);
     EXPECT_EQ(global, globalRes);
   }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/osrf/gazebo/issues/2022
Part of https://github.com/ignitionrobotics/ign-gazebo/issues/981

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

I believe that https://github.com/osrf/gazebo/issues/2022 is only an issue with the `*FromLocal*` functions. While the heading rotation from `GLOBAL` to `LOCAL` seems to be [correct](https://en.wikipedia.org/wiki/Rotation_matrix), the rotation from `LOCAL` to `GLOBAL` was not the inverse of that, which resulted in incoherent behaviour.

In order to preserve behaviour on version 6, which is being used by a lot of people who compensate for the bug, I introduced a new frame, `LOCAL2`, which can be used to get the correct calculation.

I also added several tests with sanity checks (i.e. higher latitude means further North...). 

It's my first time playing with this class, so I'd appreciate it if people paid close attention to the math and test cases, in case I'm misunderstanding something.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
