### PR TITLE
Add options to install python/ruby in system standard paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ ign_configure_project(VERSION_SUFFIX)
 # Set project-specific options
 #============================================================================
 
+option(USE_SYSTEM_PATHS_FOR_RUBY_INSTALLATION
+      "Install ruby modules in standard system paths in the system"
+      OFF)
+
 option(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION
       "Install python modules in standard system paths in the system"
       OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,13 @@ ign_configure_project(VERSION_SUFFIX)
 # Set project-specific options
 #============================================================================
 
-# ignition-math currently has no options that are unique to it
+option(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION
+      "Install python modules in standard system paths in the system"
+      OFF)
 
+option(USE_DIST_PACKAGES_FOR_PYTHON
+      "Use dist-packages instead of site-package to install python modules"
+      OFF)
 
 #============================================================================
 # Search for project-specific dependencies

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -76,7 +76,7 @@ if (PYTHONLIBS_FOUND)
     else()
       # Get install variable from Python3 module
       # Python3_SITEARCH is available from 3.12 on, workaround if needed:
-      find_package(Python3 COMPONENTS Development)
+      find_package(Python3 COMPONENTS Interpreter)
     endif()
 
     if(USE_DIST_PACKAGES_FOR_PYTHON)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -64,8 +64,34 @@ if (PYTHONLIBS_FOUND)
     $<$<CXX_COMPILER_ID:Clang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter -Wno-cast-function-type -Wno-missing-field-initializers -Wno-class-memaccess>
     $<$<CXX_COMPILER_ID:AppleClang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter -Wno-cast-function-type -Wno-missing-field-initializers -Wno-class-memaccess>
   )
+
+  if(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION)
+    if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+      execute_process(
+        COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
+	  from distutils import sysconfig as sc
+	  print(sc.get_python_lib(plat_specific=True))"
+        OUTPUT_VARIABLE Python3_SITELIB
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    else()
+      # Get install variable from Python3 module
+      # Python3_SITELIB is available from 3.12 on, workaround if needed:
+      find_package(Python3 REQUIRED)
+    endif()
+
+    if(USE_DIST_PACKAGES_FOR_PYTHON)
+      string(REPLACE "site-packages" "dist-packages" IGN_PYTHON_INSTALL_PATH ${Python3_SITELIB})
+    else()
+      # custom cmake command is returning dist-packages
+      string(REPLACE "dist-packages" "site-packages" IGN_PYTHON_INSTALL_PATH ${Python3_SITELIB})
+    endif()
+  else()
+    # If not a system installation, respect local paths
+    set(IGN_PYTHON_INSTALL_PATH ${IGN_LIB_INSTALL_DIR}/python)
+  endif()
+
   install(TARGETS ${SWIG_PY_LIB} DESTINATION ${IGN_LIB_INSTALL_DIR}/python/ignition)
-  install(FILES ${CMAKE_BINARY_DIR}/lib/python/math.py DESTINATION ${IGN_LIB_INSTALL_DIR}/python/ignition)
+  install(FILES ${CMAKE_BINARY_DIR}/lib/python/math.py DESTINATION ${IGN_PYTHON_INSTALL_PATH}/ignition)
 
   if (BUILD_TESTING)
     # Add the Python tests

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -71,27 +71,28 @@ if (PYTHONLIBS_FOUND)
         COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
 	  from distutils import sysconfig as sc
 	  print(sc.get_python_lib(plat_specific=True))"
-        OUTPUT_VARIABLE Python3_SITELIB
+        OUTPUT_VARIABLE Python3_SITEARCH
         OUTPUT_STRIP_TRAILING_WHITESPACE)
     else()
       # Get install variable from Python3 module
-      # Python3_SITELIB is available from 3.12 on, workaround if needed:
-      find_package(Python3 REQUIRED)
+      # Python3_SITEARCH is available from 3.12 on, workaround if needed:
+      find_package(Python3 COMPONENTS Development)
     endif()
 
     if(USE_DIST_PACKAGES_FOR_PYTHON)
-      string(REPLACE "site-packages" "dist-packages" IGN_PYTHON_INSTALL_PATH ${Python3_SITELIB})
+      string(REPLACE "site-packages" "dist-packages" IGN_PYTHON_INSTALL_PATH ${Python3_SITEARCH})
     else()
       # custom cmake command is returning dist-packages
-      string(REPLACE "dist-packages" "site-packages" IGN_PYTHON_INSTALL_PATH ${Python3_SITELIB})
+      string(REPLACE "dist-packages" "site-packages" IGN_PYTHON_INSTALL_PATH ${Python3_SITEARCH})
     endif()
   else()
     # If not a system installation, respect local paths
     set(IGN_PYTHON_INSTALL_PATH ${IGN_LIB_INSTALL_DIR}/python)
   endif()
 
-  install(TARGETS ${SWIG_PY_LIB} DESTINATION ${IGN_LIB_INSTALL_DIR}/python/ignition)
-  install(FILES ${CMAKE_BINARY_DIR}/lib/python/math.py DESTINATION ${IGN_PYTHON_INSTALL_PATH}/ignition)
+  set(IGN_PYTHON_INSTALL_PATH "${IGN_PYTHON_INSTALL_PATH}/ignition")
+  install(TARGETS ${SWIG_PY_LIB} DESTINATION ${IGN_PYTHON_INSTALL_PATH})
+  install(FILES ${CMAKE_BINARY_DIR}/lib/python/math.py DESTINATION ${IGN_PYTHON_INSTALL_PATH})
 
   if (BUILD_TESTING)
     # Add the Python tests

--- a/src/ruby/CMakeLists.txt
+++ b/src/ruby/CMakeLists.txt
@@ -62,7 +62,17 @@ if (RUBY_FOUND)
     ignition-math${PROJECT_VERSION_MAJOR}
   )
   target_compile_features(math PUBLIC ${IGN_CXX_${c++standard}_FEATURES})
-  install(TARGETS math DESTINATION ${IGN_LIB_INSTALL_DIR}/ruby/ignition)
+
+  if(USE_SYSTEM_PATHS_FOR_RUBY_INSTALLATION)
+    execute_process(
+      COMMAND ${RUBY_EXECUTABLE} -r rbconfig -e "print RbConfig::CONFIG['vendordir']"
+      OUTPUT_VARIABLE IGN_RUBY_INSTALL_PATH
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  else()
+      set(IGN_RUBY_INSTALL_PATH ${IGN_LIB_INSTALL_DIR}/ruby)
+  endif()
+  set(IGN_RUBY_INSTALL_PATH "${IGN_RUBY_INSTALL_PATH}/ignition")
+  install(TARGETS math DESTINATION ${IGN_RUBY_INSTALL_PATH})
 
   # Add the ruby tests
   foreach (test ${ruby_tests})


### PR DESCRIPTION
# 🎉 New feature

## Summary

Introduce two new options: `USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION` and `USE_DIST_PACKAGES_FOR_PYTHON` to support python installation in the standard directories. The local installations can go in `<path>/site-packages` (i.e /usr/lib/python3/site-packages) but for packaging Debian is recommending to use `<path>/dist-packages`.

The best way to implement this is to use the `find_package(Python3)` but is only available from 3.12 on so I've implemented a workaround invoking 


## Checklist
- [x] Signed all commits for DCO

**Note to maintainers**: Remember to use **Squash-Merge**
