### PR TITLE
Use python executable variable instead of hardcode python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ if (SWIG_FOUND)
 
   ########################################
   # Include python
+  find_package(PythonInterp REQUIRED) # change to Python3 when Bionic is EOL
   find_package(PythonLibs QUIET)
   if (NOT PYTHONLIBS_FOUND)
     message (STATUS "Searching for Python - not found.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if (SWIG_FOUND)
 
   ########################################
   # Include python
-  find_package(PythonInterp REQUIRED) # change to Python3 when Bionic is EOL
+  find_package(PythonInterp 3 REQUIRED) # change to Python3 when Bionic is EOL
   find_package(PythonLibs QUIET)
   if (NOT PYTHONLIBS_FOUND)
     message (STATUS "Searching for Python - not found.")

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -110,7 +110,7 @@ if (PYTHONLIBS_FOUND)
 
     foreach (test ${python_tests})
       add_test(NAME ${test}.py COMMAND
-        python3 ${CMAKE_SOURCE_DIR}/src/python/${test}.py)
+        "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/src/python/${test}.py")
 
       set(_env_vars)
       list(APPEND _env_vars "PYTHONPATH=${FAKE_INSTALL_PREFIX}/lib/python/")

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -110,7 +110,7 @@ if (PYTHONLIBS_FOUND)
 
     foreach (test ${python_tests})
       add_test(NAME ${test}.py COMMAND
-        "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/src/python/${test}.py")
+        "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/src/python/${test}.py")
 
       set(_env_vars)
       list(APPEND _env_vars "PYTHONPATH=${FAKE_INSTALL_PREFIX}/lib/python/")


### PR DESCRIPTION
This should prepare the software for https://github.com/ignition-tooling/release-tools/issues/508. Note that CI won't run the python/ruby test on Mac/Windows until #508 is ready.
