### PR TITLE
More suggestions to #219

### DIFF
--- a/include/ignition/math/Box.hh
+++ b/include/ignition/math/Box.hh
@@ -23,7 +23,7 @@
 #include <ignition/math/Vector3.hh>
 #include <ignition/math/Plane.hh>
 
-#include <vector>
+#include <set>
 
 namespace ignition
 {
@@ -132,15 +132,26 @@ namespace ignition
       public: Precision Volume() const;
 
       /// \brief Get the volume of the box below a plane.
-      /// \param[in] _plane The plane which cuts the box.
+      /// \param[in] _plane The plane which cuts the box, expressed in the box's
+      /// frame.
       /// \return Volume below the plane in m^3.
       public: Precision VolumeBelow(const Plane<Precision> &_plane) const;
 
       /// \brief Center of volume below the plane. This is useful when
-      /// calculating where the buoyancy should be applied.
-      /// \param[in] _plane The plane which slices the box.
+      /// calculating where buoyancy should be applied, for example.
+      /// \param[in] _plane The plane which cuts the box, expressed in the box's
+      /// frame.
+      /// \return Center of volume, in box's frame.
       public: std::optional<Vector3<Precision>>
         CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
+
+      /// \brief All the vertices which are on or below the plane.
+      /// \param[in] _plane The plane which cuts the box, expressed in the box's
+      /// frame.
+      /// \return Box vertices which are below the plane, expressed in the box's
+      /// frame.
+      public: std::set<Vector3<Precision>>
+        VerticesBelow(const Plane<Precision> &_plane) const;
 
       /// \brief Compute the box's density given a mass value. The
       /// box is assumed to be solid with uniform density. This
@@ -175,11 +186,12 @@ namespace ignition
       /// could be due to an invalid size (<=0) or density (<=0).
       public: bool MassMatrix(MassMatrix3<Precision> &_massMat) const;
 
-      /// \brief Get intersection between a plane and the box.
+      /// \brief Get intersection between a plane and the box's edges.
+      /// Edges contained on the plane are ignored.
       /// \param[in] _plane The plane against which we are testing intersection.
-      /// \returns a list of points along the edges of the box where the
+      /// \returns A list of points along the edges of the box where the
       /// intersection occurs.
-      public: std::vector<Vector3<Precision>> Intersections(
+      public: std::set<Vector3<Precision>> Intersections(
         const Plane<Precision> &_plane) const;
 
       /// \brief Size of the box.

--- a/include/ignition/math/Plane.hh
+++ b/include/ignition/math/Plane.hh
@@ -129,13 +129,13 @@ namespace ignition
       /// \param[in] _tolerance The tolerance for determining a line is
       /// parallel to the plane. Optional, default=10^-16
       /// \return The point of intersection. std::nullopt if the line is
-      /// parrallel to the plane.
+      /// parallel to the plane (including lines on the plane).
       public: std::optional<Vector3<T>> Intersection(
         const Vector3<T> &_point,
         const Vector3<T> &_gradient,
         const double &_tolerance = 1e-6) const
       {
-        if(abs(this->Normal().Dot(_gradient)) < _tolerance)
+        if (std::abs(this->Normal().Dot(_gradient)) < _tolerance)
         {
           return std::nullopt;
         }
@@ -143,7 +143,7 @@ namespace ignition
         auto param = constant / this->Normal().Dot(_gradient);
         auto intersection = _point + _gradient*param;
 
-        if(this->Size() == Vector2<T>(0, 0))
+        if (this->Size() == Vector2<T>(0, 0))
           return intersection;
 
         // Check if the point is within the size bounds
@@ -160,8 +160,8 @@ namespace ignition
         auto xBasis = rotatedXAxis.VectorProjectionLength(intersection);
         auto yBasis = rotatedYAxis.VectorProjectionLength(intersection);
 
-        if(fabs(xBasis) < this->Size().X() / 2
-        && fabs(yBasis) < this->Size().Y() / 2)
+        if (fabs(xBasis) < this->Size().X() / 2 &&
+            fabs(yBasis) < this->Size().Y() / 2)
         {
           return intersection;
         }

--- a/include/ignition/math/Plane.hh
+++ b/include/ignition/math/Plane.hh
@@ -160,8 +160,8 @@ namespace ignition
         auto xBasis = rotatedXAxis.VectorProjectionLength(intersection);
         auto yBasis = rotatedYAxis.VectorProjectionLength(intersection);
 
-        if (fabs(xBasis) < this->Size().X() / 2 &&
-            fabs(yBasis) < this->Size().Y() / 2)
+        if (std::abs(xBasis) < this->Size().X() / 2 &&
+            std::abs(yBasis) < this->Size().Y() / 2)
         {
           return intersection;
         }

--- a/include/ignition/math/Sphere.hh
+++ b/include/ignition/math/Sphere.hh
@@ -94,18 +94,20 @@ namespace ignition
 
       /// \brief Get the volume of sphere below a given plane in m^3.
       /// It is assumed that the center of the sphere is on the origin
-      /// The plane's orientation is not considered.
-      /// \param[in] _plane The plane which slices this sphere.
+      /// \param[in] _plane The plane which slices this sphere, expressed
+      /// in the sphere's reference frame.
       /// \return Volume below the sphere in m^3.
-      public: Precision VolumeBelow(const Planed &_plane) const;
+      public: Precision VolumeBelow(const Plane<Precision> &_plane) const;
 
       /// \brief Center of volume below the plane. This is useful for example
       /// when calculating where buoyancy should be applied.
-      /// \param[in] _plane The plane which slices the sphere.
+      /// \param[in] _plane The plane which slices this sphere, expressed
+      /// in the sphere's reference frame.
       /// \return The center of volume if there is anything under the plane,
-      /// otherwise return a std::nullopt.
+      /// otherwise return a std::nullopt. Expressed in the sphere's reference
+      /// frame.
       public: std::optional<Vector3<Precision>>
-        CenterOfVolumeBelow(const Planed &_plane) const;
+        CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
       /// \brief Compute the sphere's density given a mass value. The
       /// sphere is assumed to be solid with uniform density. This

--- a/include/ignition/math/detail/Box.hh
+++ b/include/ignition/math/detail/Box.hh
@@ -20,6 +20,7 @@
 #include "ignition/math/Triangle3.hh"
 
 #include <algorithm>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -211,7 +212,7 @@ T Box<T>::VolumeBelow(const Plane<T> &_plane) const
   for (const auto &triangle : triangles)
   {
     auto crossProduct = (triangle.first[2]).Cross(triangle.first[1]);
-    auto meshVolume = std::fabs(crossProduct.Dot(triangle.first[0]));
+    auto meshVolume = std::abs(crossProduct.Dot(triangle.first[0]));
     volume += triangle.second * meshVolume;
   }
 

--- a/include/ignition/math/detail/Sphere.hh
+++ b/include/ignition/math/detail/Sphere.hh
@@ -97,7 +97,7 @@ T Sphere<T>::Volume() const
 
 //////////////////////////////////////////////////
 template<typename T>
-T Sphere<T>::VolumeBelow(const Planed &_plane) const
+T Sphere<T>::VolumeBelow(const Plane<T> &_plane) const
 {
   auto r = this->radius;
   // get nearest point to center on plane
@@ -121,18 +121,18 @@ T Sphere<T>::VolumeBelow(const Planed &_plane) const
 //////////////////////////////////////////////////
 template<typename T>
 std::optional<Vector3<T>>
- Sphere<T>::CenterOfVolumeBelow(const Planed &_plane) const
+ Sphere<T>::CenterOfVolumeBelow(const Plane<T> &_plane) const
 {
   auto r = this->radius;
   // get nearest point to center on plane
   auto dist = _plane.Distance(Vector3d(0, 0, 0));
 
-  if(dist < -r)
+  if (dist < -r)
   {
     // sphere is completely below plane
     return Vector3<T>{0, 0, 0};
   }
-  else if(dist > r)
+  else if (dist > r)
   {
     // sphere is completely above plane
     return std::nullopt;

--- a/src/Plane_TEST.cc
+++ b/src/Plane_TEST.cc
@@ -172,11 +172,34 @@ TEST(PlaneTest, Intersection)
     EXPECT_TRUE(intersect.has_value());
     EXPECT_EQ(intersect.value(), Vector3d(2, 2, 0));
   }
+  // Lines on plane
+  {
+    auto intersect = plane.Intersection(Vector3d(2, 0, 0), Vector3d(0, 1, 0));
+    EXPECT_FALSE(intersect.has_value());
+  }
+  {
+    auto intersect = plane.Intersection(Vector3d(2, 0, 0), Vector3d(0, 0, 1));
+    EXPECT_FALSE(intersect.has_value());
+  }
+  {
+    auto intersect = plane.Intersection(Vector3d(2, 0, 0), Vector3d(0, 1, 1));
+    EXPECT_FALSE(intersect.has_value());
+  }
+  // Lines parallel to plane
   {
     auto intersect = plane.Intersection(Vector3d(0, 0, 0), Vector3d(0, 1, 0));
     EXPECT_FALSE(intersect.has_value());
   }
+  {
+    auto intersect = plane.Intersection(Vector3d(0, 0, 0), Vector3d(0, 0, 1));
+    EXPECT_FALSE(intersect.has_value());
+  }
+  {
+    auto intersect = plane.Intersection(Vector3d(0, 0, 0), Vector3d(0, 1, 1));
+    EXPECT_FALSE(intersect.has_value());
+  }
 
+  // Bounded plane
   {
     Planed planeBounded(Vector3d(0, 0, 1), Vector2d(0.5, 0.5), 0);
     auto intersect1 =

--- a/src/Sphere_TEST.cc
+++ b/src/Sphere_TEST.cc
@@ -186,11 +186,13 @@ TEST(SphereTest, CenterOfVolumeBelow)
   double r = 2;
   math::Sphered sphere(r);
 
+  // Entire sphere below plane
   {
     math::Planed _plane(math::Vector3d{0, 0, 1}, math::Vector2d(0, 0), 2 * r);
     EXPECT_EQ(Vector3d(0, 0, 0), sphere.CenterOfVolumeBelow(_plane));
   }
 
+  // Entire sphere above plane
   {
     math::Planed _plane(math::Vector3d{0, 0, 1}, math::Vector2d(0, 0), -2 * r);
     EXPECT_FALSE(sphere.CenterOfVolumeBelow(_plane).has_value());


### PR DESCRIPTION
* Style updates
* Use `set` instead of `vector` to avoid duplicates and return a predictable order (sorted). Without this, sometimes `Intersections` may return duplicate points.
* Use `Precision` for the functions in `Sphere`
* Moved some duplicate logic to a new `Box::VerticesBelow` function
* Added more test cases