### PR TITLE
Avoid assertAlmostEqual for python strings

### DIFF
--- a/src/python/Color_TEST.py
+++ b/src/python/Color_TEST.py
@@ -296,7 +296,7 @@ class TestColor(unittest.TestCase):
 
     def test_stream_out(self):
         c = Color(0.1, 0.2, 0.3, 0.5)
-        self.assertAlmostEqual(str(c), "0.1 0.2 0.3 0.5")
+        self.assertEqual(str(c), "0.1 0.2 0.3 0.5")
 
     def test_HSV(self):
         clr = Color()

--- a/src/python/Pose3_TEST.py
+++ b/src/python/Pose3_TEST.py
@@ -142,7 +142,7 @@ class TestPose3(unittest.TestCase):
 
     def test_stream_out(self):
         p = Pose3d(0.1, 1.2, 2.3, 0.0, 0.1, 1.0)
-        self.assertAlmostEqual(str(p), "0.1 1.2 2.3 0 0.1 1")
+        self.assertEqual(str(p), "0.1 1.2 2.3 0 0.1 1")
 
     def test_mutable_pose(self):
         pose = Pose3d(0, 1, 2, 0, 0, 0)


### PR DESCRIPTION
# 🦟 Bug fix

Attempted fix for #250 

## Summary

The `Pose3_TEST.py` test is failing on `arm64` with complaints about subtracting strings in `assertAlmostEqual`. I believe `assertAlmostEqual` is not intended for comparing strings. It can occasionally work if they match exactly ([see early return on `==` match](https://github.com/python/cpython/blob/v3.8.12/Lib/unittest/case.py#L923-L939)), but it fails dramatically if they don't match exactly. This changes two instances of `assertAlmostEqual` to `assertEqual` for string comparisons.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
