### PR TITLE
Pose3_TEST.py: use 0.01 (not 0) in string test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(ignition-cmake2 2.8.0 REQUIRED)
 # Configure the project
 #============================================================================
 set (c++standard 17)
-ign_configure_project(VERSION_SUFFIX pre1)
+ign_configure_project(VERSION_SUFFIX pre2)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@
 1. Avoid assertAlmostEqual for python strings
     * [Pull request #255](https://github.com/ignitionrobotics/ign-math/pull/255)
 
+1. Pose3_TEST.py: use 0.01 (not 0) in string test
+    * [Pull request #257](https://github.com/ignitionrobotics/ign-math/pull/257)
+
 ## Ignition Math 6.9.0 (2021-09-28)
 
 1. Volume below a plane for spheres and boxes

--- a/src/python/Pose3_TEST.py
+++ b/src/python/Pose3_TEST.py
@@ -141,8 +141,8 @@ class TestPose3(unittest.TestCase):
         self.assertTrue(pose.rot() == Quaterniond(1, 0, 0))
 
     def test_stream_out(self):
-        p = Pose3d(0.1, 1.2, 2.3, 0.0, 0.1, 1.0)
-        self.assertEqual(str(p), "0.1 1.2 2.3 0 0.1 1")
+        p = Pose3d(0.1, 1.2, 2.3, 0.01, 0.1, 1.0)
+        self.assertEqual(str(p), "0.1 1.2 2.3 0.01 0.1 1")
 
     def test_mutable_pose(self):
         pose = Pose3d(0, 1, 2, 0, 0, 0)


### PR DESCRIPTION
# 🦟 Bug fix

I believe this fixes #250

## Summary

`Pose3_TEST.py` is failing on `arm64` due to a `-0` instead of `0` in an expected string. This changes the constant from `0` to `0.01` to workaround the ambiguity.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
