### PR TITLE
Removed SetLength const method

### DIFF
--- a/include/ignition/math/Cylinder.hh
+++ b/include/ignition/math/Cylinder.hh
@@ -100,10 +100,6 @@ namespace ignition
       public: void SetRotationalOffset(
                   const Quaternion<Precision> &_rotOffset);
 
-      /// \brief Set the length in meters.
-      /// \param[in] _length The length of the cylinder in meters.
-      public: void SetLength(const Precision _length) const;
-
       /// \brief Get the material associated with this cylinder.
       /// \return The material assigned to this cylinder
       public: const Material &Mat() const;


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

Remove `SetLength() const` method. I think this method does not make sense. It's imposible to set the Lenght in a const method.

There is no implementation for this method.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
