### PR TITLE
Export PYTHONPATH when sourcing the workspace

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,4 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+{
+  "hooks": ["share/ignition-math6/setup.sh"]
+}

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -80,6 +80,18 @@ if (PYTHONLIBS_FOUND)
     set(IGN_PYTHON_INSTALL_PATH ${IGN_LIB_INSTALL_DIR}/python)
   endif()
 
+  # TODO(ahcorde): Use ign-cmake to include hooks
+  # Refer to this issue: https://github.com/ignitionrobotics/ign-cmake/issues/185
+  configure_file(
+    "setup.sh.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/share/setup.sh" @ONLY
+  )
+
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/share/setup.sh
+    DESTINATION share/${PROJECT_NAME}
+  )
+
   set(IGN_PYTHON_INSTALL_PATH "${IGN_PYTHON_INSTALL_PATH}/ignition")
   install(TARGETS ${SWIG_PY_LIB} DESTINATION ${IGN_PYTHON_INSTALL_PATH})
   install(FILES ${CMAKE_BINARY_DIR}/lib/python/math.py DESTINATION ${IGN_PYTHON_INSTALL_PATH})

--- a/src/python/setup.sh.in
+++ b/src/python/setup.sh.in
@@ -1,0 +1,3 @@
+# generated from ignition-math/setup.sh.in
+
+export PYTHONPATH=@CMAKE_INSTALL_PREFIX@/@IGN_PYTHON_INSTALL_PATH@:$PYTHONPATH


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

This PR is related to this issues https://github.com/ignitionrobotics/ign-math/issues/270

When compiling from source and loading the workspace we should be able to setup the PYTHONPATH to allow user to use the Python bindings

There is a discussion in the ign-cmake https://github.com/ignitionrobotics/ign-cmake/issues/185 repository to include this functionality.

One cons about this solution if that if you source the workspace several times you will append the path to the pythonpath each time.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

