### PR TITLE
AxisAlignedBox: rename some python methods

### DIFF
--- a/src/python/AxisAlignedBox.i
+++ b/src/python/AxisAlignedBox.i
@@ -65,10 +65,13 @@ namespace ignition
 
       public: virtual ~AxisAlignedBox();
 
+      %rename(x_length) XLength;
       public: double XLength() const;
 
+      %rename(y_length) YLength;
       public: double YLength() const;
 
+      %rename(z_length) ZLength;
       public: double ZLength() const;
 
       public: math::Vector3<double> Size() const;

--- a/src/python/AxisAlignedBox_TEST.py
+++ b/src/python/AxisAlignedBox_TEST.py
@@ -65,9 +65,9 @@ class TestAxisAlignedBox(unittest.TestCase):
 
     def test_length(self):
         box = AxisAlignedBox(Vector3d(0, -1, 2), Vector3d(1, -2, 3))
-        self.assertEqual(box.xlength(), 1)
-        self.assertEqual(box.ylength(), 1)
-        self.assertEqual(box.zlength(), 1)
+        self.assertEqual(box.x_length(), 1)
+        self.assertEqual(box.y_length(), 1)
+        self.assertEqual(box.z_length(), 1)
 
     def test_size(self):
         box = AxisAlignedBox(Vector3d(0, -1, 2), Vector3d(1, -2, 3))
@@ -92,9 +92,9 @@ class TestAxisAlignedBox(unittest.TestCase):
 
         self.assertEqual(defaultAxisAlignedBox1.size(), Vector3d(0, 0, 0))
 
-        self.assertEqual(defaultAxisAlignedBox1.xlength(), 0)
-        self.assertEqual(defaultAxisAlignedBox1.ylength(), 0)
-        self.assertEqual(defaultAxisAlignedBox1.zlength(), 0)
+        self.assertEqual(defaultAxisAlignedBox1.x_length(), 0)
+        self.assertEqual(defaultAxisAlignedBox1.y_length(), 0)
+        self.assertEqual(defaultAxisAlignedBox1.z_length(), 0)
 
         self.assertEqual(defaultAxisAlignedBox1.center(), Vector3d(0, 0, 0))
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes the format of python method names in AxisAlignedBox class

## Summary

Rename the `[XYZ]Length` methods to `[xyz]_length` to improve readability. This is similar to changes made in [Quaternion](https://github.com/ignitionrobotics/ign-math/blob/ignition-math6_6.9.2/src/python/Quaternion.i#L92-L97), [PID](https://github.com/ignitionrobotics/ign-math/blob/ignition-math6_6.9.2/src/python/PID.i#L50-L72), and `OrientedBox` ( https://github.com/ignitionrobotics/ign-math/pull/276#discussion_r745202005 ).

This changes the python API but is ok because the python bindings for this class have not yet been released.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
