### PR TITLE
quaternion_from_euler example: input degrees

### DIFF
--- a/examples/quaternion_from_euler.cc
+++ b/examples/quaternion_from_euler.cc
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
   if (argc != 4)
   {
     std::cerr << "Invalid usage\n\n"
-              << "Usage (angles specified in radians):\n"
+              << "Usage (angles specified in degrees):\n"
               << "  quaternion_from_euler "
               << "<float_roll> <float_pitch> <float_yaw>\n\n"
               << "Example\n"
@@ -53,9 +53,9 @@ int main(int argc, char **argv)
     return -1;
   }
 
-  double roll = strToDouble(argv[1]);
-  double pitch = strToDouble(argv[2]);
-  double yaw = strToDouble(argv[3]);
+  double roll = IGN_DTOR(strToDouble(argv[1]));
+  double pitch = IGN_DTOR(strToDouble(argv[2]));
+  double yaw = IGN_DTOR(strToDouble(argv[3]));
 
   std::cout << "Converting Euler angles:\n";
   printf(" roll  % .6f radians\n"


### PR DESCRIPTION
# 🦟 Bug fix

Improve units in example program

## Summary

It's easier to specify angles in degrees than radians, so change this example to accept user input in degrees.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
