### PR TITLE
Fix windows warnings in Vector2, 3 and 4

### DIFF
--- a/include/ignition/math/Vector2.hh
+++ b/include/ignition/math/Vector2.hh
@@ -108,10 +108,10 @@ namespace ignition
       {
         double d = this->Length();
 
-        if (!equal<T>(d, static_cast<T>(0.0)))
+        if (!equal<T>(static_cast<T>(d), static_cast<T>(0.0)))
         {
-          this->data[0] /= d;
-          this->data[1] /= d;
+          this->data[0] /= static_cast<T>(d);
+          this->data[1] /= static_cast<T>(d);
         }
       }
 
@@ -128,8 +128,8 @@ namespace ignition
       /// \return the result
       public: Vector2 Round()
       {
-        this->data[0] = nearbyint(this->data[0]);
-        this->data[1] = nearbyint(this->data[1]);
+        this->data[0] = static_cast<T>(nearbyint(this->data[0]));
+        this->data[1] = static_cast<T>(nearbyint(this->data[1]));
         return *this;
       }
 

--- a/include/ignition/math/Vector2.hh
+++ b/include/ignition/math/Vector2.hh
@@ -18,6 +18,7 @@
 #define IGNITION_MATH_VECTOR2_HH_
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 
 #include <ignition/math/Helpers.hh>
@@ -106,12 +107,12 @@ namespace ignition
       /// \brief Normalize the vector length
       public: void Normalize()
       {
-        double d = this->Length();
+        T d = this->Length();
 
-        if (!equal<T>(static_cast<T>(d), static_cast<T>(0.0)))
+        if (!equal<T>(d, static_cast<T>(0.0)))
         {
-          this->data[0] /= static_cast<T>(d);
-          this->data[1] /= static_cast<T>(d);
+          this->data[0] /= d;
+          this->data[1] /= d;
         }
       }
 
@@ -128,8 +129,8 @@ namespace ignition
       /// \return the result
       public: Vector2 Round()
       {
-        this->data[0] = static_cast<T>(nearbyint(this->data[0]));
-        this->data[1] = static_cast<T>(nearbyint(this->data[1]));
+        this->data[0] = std::nearbyint(this->data[0]);
+        this->data[1] = std::nearbyint(this->data[1]);
         return *this;
       }
 

--- a/include/ignition/math/Vector3.hh
+++ b/include/ignition/math/Vector3.hh
@@ -163,9 +163,9 @@ namespace ignition
       /// \return the result
       public: Vector3 Round()
       {
-        this->data[0] = static_cast<T>(nearbyint(this->data[0]));
-        this->data[1] = static_cast<T>(nearbyint(this->data[1]));
-        this->data[2] = static_cast<T>(nearbyint(this->data[2]));
+        this->data[0] = std::nearbyint(this->data[0]);
+        this->data[1] = std::nearbyint(this->data[1]);
+        this->data[2] = std::nearbyint(this->data[2]);
         return *this;
       }
 

--- a/include/ignition/math/Vector3.hh
+++ b/include/ignition/math/Vector3.hh
@@ -163,9 +163,9 @@ namespace ignition
       /// \return the result
       public: Vector3 Round()
       {
-        this->data[0] = nearbyint(this->data[0]);
-        this->data[1] = nearbyint(this->data[1]);
-        this->data[2] = nearbyint(this->data[2]);
+        this->data[0] = static_cast<T>(nearbyint(this->data[0]));
+        this->data[1] = static_cast<T>(nearbyint(this->data[1]));
+        this->data[2] = static_cast<T>(nearbyint(this->data[2]));
         return *this;
       }
 
@@ -237,7 +237,7 @@ namespace ignition
       /// \return an orthogonal vector
       public: Vector3 Perpendicular() const
       {
-        static const T sqrZero = 1e-06 * 1e-06;
+        static const T sqrZero = static_cast<T>(1e-06 * 1e-06);
 
         Vector3<T> perp = this->Cross(Vector3(1, 0, 0));
 

--- a/include/ignition/math/Vector4.hh
+++ b/include/ignition/math/Vector4.hh
@@ -18,6 +18,7 @@
 #define IGNITION_MATH_VECTOR4_HH_
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 
 #include <ignition/math/Matrix4.hh>
@@ -121,10 +122,10 @@ namespace ignition
       /// \brief Round to near whole number.
       public: void Round()
       {
-        this->data[0] = static_cast<T>(nearbyint(this->data[0]));
-        this->data[1] = static_cast<T>(nearbyint(this->data[1]));
-        this->data[2] = static_cast<T>(nearbyint(this->data[2]));
-        this->data[3] = static_cast<T>(nearbyint(this->data[3]));
+        this->data[0] = std::nearbyint(this->data[0]);
+        this->data[1] = std::nearbyint(this->data[1]);
+        this->data[2] = std::nearbyint(this->data[2]);
+        this->data[3] = std::nearbyint(this->data[3]);
       }
 
       /// \brief Get a rounded version of this vector

--- a/include/ignition/math/Vector4.hh
+++ b/include/ignition/math/Vector4.hh
@@ -121,10 +121,10 @@ namespace ignition
       /// \brief Round to near whole number.
       public: void Round()
       {
-        this->data[0] = nearbyint(this->data[0]);
-        this->data[1] = nearbyint(this->data[1]);
-        this->data[2] = nearbyint(this->data[2]);
-        this->data[3] = nearbyint(this->data[3]);
+        this->data[0] = static_cast<T>(nearbyint(this->data[0]));
+        this->data[1] = static_cast<T>(nearbyint(this->data[1]));
+        this->data[2] = static_cast<T>(nearbyint(this->data[2]));
+        this->data[3] = static_cast<T>(nearbyint(this->data[3]));
       }
 
       /// \brief Get a rounded version of this vector


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🦟 Warnings

## Summary

Fix windows warnings in Vector2, 3 and 4

## Checklist
- x ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
