### PR TITLE
Modified cmake target name for Ruby interfaces

### DIFF
--- a/src/ruby/CMakeLists.txt
+++ b/src/ruby/CMakeLists.txt
@@ -39,29 +39,35 @@ if (RUBY_FOUND)
 
   # Turn on c++
   set_source_files_properties(${swig_i_files} ruby.i PROPERTIES CPLUSPLUS ON)
+  set(SWIG_RB_LIB rbmath)
+  set(SWIG_RB_LIB_OUTPUT math)
 
   # Create the ruby library
-
   set(CMAKE_SWIG_OUTDIR "${CMAKE_BINARY_DIR}/lib/ruby")
   if(CMAKE_VERSION VERSION_GREATER 3.8.0)
-    SWIG_ADD_LIBRARY(math LANGUAGE ruby SOURCES ruby.i ${swig_i_files})
+    SWIG_ADD_LIBRARY(${SWIG_RB_LIB} LANGUAGE ruby SOURCES ruby.i ${swig_i_files})
   else()
-    SWIG_ADD_MODULE(math ruby ruby.i ${swig_i_files})
+    SWIG_ADD_MODULE(${SWIG_RB_LIB} ruby ruby.i ${swig_i_files})
   endif()
 
   # Suppress warnings on SWIG-generated files
-  target_compile_options(math PRIVATE
+  target_compile_options(${SWIG_RB_LIB} PRIVATE
     $<$<CXX_COMPILER_ID:GNU>:-Wno-pedantic -Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
     $<$<CXX_COMPILER_ID:Clang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
     $<$<CXX_COMPILER_ID:AppleClang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
   )
-  target_include_directories(math SYSTEM PUBLIC ${RUBY_INCLUDE_DIRS})
+  target_include_directories(${SWIG_RB_LIB} SYSTEM PUBLIC ${RUBY_INCLUDE_DIRS})
 
-  SWIG_LINK_LIBRARIES(math
+  SWIG_LINK_LIBRARIES(${SWIG_RB_LIB}
     ${RUBY_LIBRARY}
     ignition-math${PROJECT_VERSION_MAJOR}
   )
-  target_compile_features(math PUBLIC ${IGN_CXX_${c++standard}_FEATURES})
+  target_compile_features(${SWIG_RB_LIB} PUBLIC ${IGN_CXX_${c++standard}_FEATURES})
+
+  set_target_properties(${SWIG_RB_LIB}
+    PROPERTIES
+      OUTPUT_NAME ${SWIG_RB_LIB_OUTPUT}
+  )
 
   if(USE_SYSTEM_PATHS_FOR_RUBY_INSTALLATION)
     execute_process(
@@ -72,12 +78,16 @@ if (RUBY_FOUND)
       set(IGN_RUBY_INSTALL_PATH ${IGN_LIB_INSTALL_DIR}/ruby)
   endif()
   set(IGN_RUBY_INSTALL_PATH "${IGN_RUBY_INSTALL_PATH}/ignition")
-  install(TARGETS math DESTINATION ${IGN_RUBY_INSTALL_PATH})
+  install(TARGETS ${SWIG_RB_LIB} DESTINATION ${IGN_RUBY_INSTALL_PATH})
 
   # Add the ruby tests
+  set(_env_vars)
+  list(APPEND _env_vars "LD_LIBRARY_PATH=${FAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH}")
   foreach (test ${ruby_tests})
     add_test(NAME ${test}.rb COMMAND
-      ruby -I${CMAKE_BINARY_DIR}/lib ${CMAKE_SOURCE_DIR}/src/ruby/${test}.rb
+      ruby -I${FAKE_INSTALL_PREFIX}/lib/ruby/ignition ${CMAKE_SOURCE_DIR}/src/ruby/${test}.rb
    	  --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${test}rb.xml)
+    set_tests_properties(${test}.rb PROPERTIES
+      ENVIRONMENT "${_env_vars}")
   endforeach()
 endif()


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

this PR blocks this other PR https://github.com/ignitionrobotics/ign-math/pull/280/files

pybind11 requires to call the target with the same name of the exported module. We would like to use `import gazebo.math` with Python interfaces. We are using this target name for the Ruby SWIG modules,  SWIG allows to set some variable to call the module with the desired name.

This is just a change of the target name should not affect behaviour.

## Summary

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
