### PR TITLE
Use nested struct to provide constexpr constants

### DIFF
--- a/include/ignition/math/Color.hh
+++ b/include/ignition/math/Color.hh
@@ -36,22 +36,25 @@ namespace ignition
     /// (A) component. Each color component is in the range [0..1].
     class IGNITION_MATH_VISIBLE Color
     {
+      // This struct of named constants is defined later in this file.
+      public: struct IGNITION_MATH_VISIBLE Constant;
+
       /// \brief (1, 1, 1)
-      public: static const Color White;
+      public: IGN_DEPRECATED(7) static const Color White;
       /// \brief (0, 0, 0)
-      public: static const Color Black;
+      public: IGN_DEPRECATED(7) static const Color Black;
       /// \brief (1, 0, 0)
-      public: static const Color Red;
+      public: IGN_DEPRECATED(7) static const Color Red;
       /// \brief (0, 1, 0)
-      public: static const Color Green;
+      public: IGN_DEPRECATED(7) static const Color Green;
       /// \brief (0, 0, 1)
-      public: static const Color Blue;
+      public: IGN_DEPRECATED(7) static const Color Blue;
       /// \brief (1, 1, 0)
-      public: static const Color Yellow;
+      public: IGN_DEPRECATED(7) static const Color Yellow;
       /// \brief (1, 0, 1)
-      public: static const Color Magenta;
+      public: IGN_DEPRECATED(7) static const Color Magenta;
       /// \brief (0, 1, 1)
-      public: static const Color Cyan;
+      public: IGN_DEPRECATED(7) static const Color Cyan;
 
       /// \typedef RGBA
       /// \brief A RGBA packed value as an unsigned int
@@ -70,22 +73,26 @@ namespace ignition
       public: typedef unsigned int ABGR;
 
       /// \brief Constructor
-      public: Color();
+      public: constexpr Color() = default;
 
       /// \brief Constructor
       /// \param[in] _r Red value (range 0 to 1)
       /// \param[in] _g Green value (range 0 to 1)
       /// \param[in] _b Blue value (range 0 to 1)
       /// \param[in] _a Alpha value (0=transparent, 1=opaque)
-      public: Color(const float _r, const float _g, const float _b,
-                  const float _a = 1.0);
+      public: constexpr Color(const float _r, const float _g, const float _b,
+                              const float _a = 1.0)
+      : r(_r), g(_g), b(_b), a(_a)
+      {
+        this->Clamp();
+      }
 
       /// \brief Copy Constructor
       /// \param[in] _clr Color to copy
-      public: Color(const Color &_clr);
+      public: constexpr Color(const Color &_clr) = default;
 
       /// \brief Destructor
-      public: virtual ~Color();
+      public: ~Color() = default;
 
       /// \brief Reset the color to default values to red=0, green=0,
       /// blue=0, alpha=1.
@@ -123,7 +130,7 @@ namespace ignition
       /// \brief Equal operator
       /// \param[in] _pt Color to copy
       /// \return Reference to this color
-      public: Color &operator=(const Color &_pt);
+      public: constexpr Color &operator=(const Color &_pt) = default;
 
       /// \brief Array index operator
       /// \param[in] _index Color component index(0=red, 1=green, 2=blue,
@@ -242,7 +249,18 @@ namespace ignition
       public: bool operator!=(const Color &_pt) const;
 
       /// \brief Clamp the color values to valid ranges
-      private: void Clamp();
+      private: constexpr void Clamp()
+      {
+        // The comparisons here are carefully written to handle NaNs correctly.
+        if (!(this->r >= 0)) { this->r = 0; }
+        if (!(this->g >= 0)) { this->g = 0; }
+        if (!(this->b >= 0)) { this->b = 0; }
+        if (!(this->a >= 0)) { this->a = 0; }
+        if (this->r > 1) { this->r = this->r/255.0f; }
+        if (this->g > 1) { this->g = this->g/255.0f; }
+        if (this->b > 1) { this->b = this->b/255.0f; }
+        if (this->a > 1) { this->a = 1; }
+      }
 
       /// \brief Stream insertion operator
       /// \param[in] _out the output stream
@@ -345,6 +363,27 @@ namespace ignition
 
       /// \brief Alpha value
       private: float a = 1;
+    };
+
+    /// \class Constant Color.hh ignition/math/Color.hh
+    /// \brief Provides named static constants for colors.
+    struct IGNITION_MATH_VISIBLE Color::Constant {
+      /// \brief (1, 1, 1)
+      public: static constexpr Color White{1, 1, 1};
+      /// \brief (0, 0, 0)
+      public: static constexpr Color Black{0, 0, 0};
+      /// \brief (1, 0, 0)
+      public: static constexpr Color Red{1, 0, 0};
+      /// \brief (0, 1, 0)
+      public: static constexpr Color Green{0, 1, 0};
+      /// \brief (0, 0, 1)
+      public: static constexpr Color Blue{0, 0, 1};
+      /// \brief (1, 1, 0)
+      public: static constexpr Color Yellow{1, 1, 0};
+      /// \brief (1, 0, 1)
+      public: static constexpr Color Magenta{1, 0, 1};
+      /// \brief (0, 1, 1)
+      public: static constexpr Color Cyan{0, 1, 1};
     };
     }
   }

--- a/src/Color.cc
+++ b/src/Color.cc
@@ -31,29 +31,6 @@ const Color Color::Yellow = Color(1, 1, 0, 1);
 const Color Color::Magenta = Color(1, 0, 1, 1);
 const Color Color::Cyan = Color(0, 1, 1, 1);
 
-//////////////////////////////////////////////////
-Color::Color()
-{
-}
-
-//////////////////////////////////////////////////
-Color::Color(const float _r, const float _g, const float _b, const float _a)
-: r(_r), g(_g), b(_b), a(_a)
-{
-  this->Clamp();
-}
-
-//////////////////////////////////////////////////
-Color::Color(const Color &_pt)
-: r(_pt.r), g(_pt.g), b(_pt.b), a(_pt.a)
-{
-  this->Clamp();
-}
-
-//////////////////////////////////////////////////
-Color::~Color()
-{
-}
 
 //////////////////////////////////////////////////
 void Color::Reset()
@@ -373,17 +350,6 @@ void Color::SetFromABGR(const Color::ABGR _v)
 }
 
 //////////////////////////////////////////////////
-Color &Color::operator=(const Color &_clr)
-{
-  this->r = _clr.r;
-  this->g = _clr.g;
-  this->b = _clr.b;
-  this->a = _clr.a;
-
-  return *this;
-}
-
-//////////////////////////////////////////////////
 Color Color::operator+(const Color &_pt) const
 {
   return Color(this->r + _pt.r, this->g + _pt.g,
@@ -498,22 +464,6 @@ bool Color::operator==(const Color &_pt) const
 bool Color::operator!=(const Color &_pt) const
 {
   return !(*this == _pt);
-}
-
-//////////////////////////////////////////////////
-void Color::Clamp()
-{
-  this->r = this->r < 0 || isnan(this->r) ? 0: this->r;
-  this->r = this->r > 1 ? this->r/255.0f: this->r;
-
-  this->g = this->g < 0 || isnan(this->g) ? 0: this->g;
-  this->g = this->g > 1 ? this->g/255.0f: this->g;
-
-  this->b = this->b < 0 || isnan(this->b) ? 0: this->b;
-  this->b = this->b > 1 ? this->b/255.0f: this->b;
-
-  this->a = this->a < 0 || isnan(this->a) ? 0: this->a;
-  this->a = this->a > 1 ? 1.0f: this->a;
 }
 
 //////////////////////////////////////////////////

--- a/src/Color_TEST.cc
+++ b/src/Color_TEST.cc
@@ -66,6 +66,50 @@ TEST(Color, ConstColors)
 }
 
 /////////////////////////////////////////////////
+TEST(Color, ConstexprColors)
+{
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::White.R());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::White.G());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::White.B());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::White.A());
+
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Black.R());
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Black.G());
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Black.B());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Black.A());
+
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Red.R());
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Red.G());
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Red.B());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Red.A());
+
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Green.R());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Green.G());
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Green.B());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Green.A());
+
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Blue.R());
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Blue.G());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Blue.B());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Blue.A());
+
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Yellow.R());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Yellow.G());
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Yellow.B());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Yellow.A());
+
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Magenta.R());
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Magenta.G());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Magenta.B());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Magenta.A());
+
+  EXPECT_FLOAT_EQ(0.0f, math::Color::Constant::Cyan.R());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Cyan.G());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Cyan.B());
+  EXPECT_FLOAT_EQ(1.0f, math::Color::Constant::Cyan.A());
+}
+
+/////////////////////////////////////////////////
 TEST(Color, Color)
 {
   math::Color clr0;


### PR DESCRIPTION
# 🦟 Bug fix

A portion of #269.

## Summary

Use constexpr for simple static constants, to avoid the C++ global static construction and destruction order fiascos.

This is an alternative approach vs #283.  Due to MSVC's apparent limitiations, the only way to provide inline static constants is via a helper struct (or namespace-scoped globals), so that the `class Color` exists as a complete type prior to declaring constants that use it.

Deprecate the const-only (non-constexpr) spelling of the constants.

At the moment, only Color has been refactored with this pattern while we discuss the implications.

In this version of the fix, we have an API+ABI break (with a deprecation transition), and thus will require users to refactor their code.  In the #283 version of the fix, we remain API compatible (but still break ABI).

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

