### PR TITLE
Use <ostream> and <istream> narrower includes, not <iostream>

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,9 @@
 1. Prevent -0 with out stream operator
     * [Pull request 206](https://github.com/ignitionrobotics/ign-math/pull/206)
 
+1. Use <ostream> and <istream> narrower includes, not <iostream>
+    * [Pull request 287](https://github.com/ignitionrobotics/ign-math/pull/287)
+
 ## Ignition Math 6.x
 
 ### Ignition Math 6.x.x

--- a/include/ignition/math/Angle.hh
+++ b/include/ignition/math/Angle.hh
@@ -17,7 +17,8 @@
 #ifndef IGNITION_MATH_ANGLE_HH_
 #define IGNITION_MATH_ANGLE_HH_
 
-#include <iostream>
+#include <istream>
+#include <ostream>
 #include <ignition/math/Helpers.hh>
 #include <ignition/math/config.hh>
 

--- a/include/ignition/math/AxisAlignedBox.hh
+++ b/include/ignition/math/AxisAlignedBox.hh
@@ -17,7 +17,7 @@
 #ifndef IGNITION_MATH_AXISALIGNEDBOX_HH_
 #define IGNITION_MATH_AXISALIGNEDBOX_HH_
 
-#include <iostream>
+#include <ostream>
 #include <tuple>
 #include <ignition/math/config.hh>
 #include <ignition/math/Helpers.hh>

--- a/include/ignition/math/Color.hh
+++ b/include/ignition/math/Color.hh
@@ -17,8 +17,9 @@
 #ifndef IGNITION_MATH_COLOR_HH_
 #define IGNITION_MATH_COLOR_HH_
 
-#include <iostream>
 #include <cctype>
+#include <istream>
+#include <ostream>
 
 #include <ignition/math/Helpers.hh>
 #include <ignition/math/Vector3.hh>

--- a/include/ignition/math/Helpers.hh
+++ b/include/ignition/math/Helpers.hh
@@ -22,7 +22,7 @@
 #include <cmath>
 #include <cstdint>
 #include <iomanip>
-#include <iostream>
+#include <ostream>
 #include <limits>
 #include <regex>
 #include <sstream>

--- a/include/ignition/math/OrientedBox.hh
+++ b/include/ignition/math/OrientedBox.hh
@@ -17,7 +17,7 @@
 #ifndef IGNITION_MATH_ORIENTEDBOX_HH_
 #define IGNITION_MATH_ORIENTEDBOX_HH_
 
-#include <iostream>
+#include <ostream>
 #include <ignition/math/Helpers.hh>
 #include <ignition/math/MassMatrix3.hh>
 #include <ignition/math/Material.hh>

--- a/include/ignition/math/Temperature.hh
+++ b/include/ignition/math/Temperature.hh
@@ -17,8 +17,9 @@
 #ifndef IGNITION_MATH_TEMPERATURE_HH_
 #define IGNITION_MATH_TEMPERATURE_HH_
 
-#include <iostream>
+#include <istream>
 #include <memory>
+#include <ostream>
 
 #include <ignition/math/config.hh>
 #include "ignition/math/Helpers.hh"

--- a/include/ignition/math/Vector3.hh
+++ b/include/ignition/math/Vector3.hh
@@ -17,10 +17,10 @@
 #ifndef IGNITION_MATH_VECTOR3_HH_
 #define IGNITION_MATH_VECTOR3_HH_
 
-#include <iostream>
-#include <fstream>
-#include <cmath>
 #include <algorithm>
+#include <cmath>
+#include <istream>
+#include <ostream>
 
 #include <ignition/math/Helpers.hh>
 #include <ignition/math/config.hh>

--- a/include/ignition/math/graph/Edge.hh
+++ b/include/ignition/math/graph/Edge.hh
@@ -20,8 +20,8 @@
 // uint64_t
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <map>
+#include <ostream>
 #include <set>
 
 #include <ignition/math/config.hh>

--- a/include/ignition/math/graph/Graph.hh
+++ b/include/ignition/math/graph/Graph.hh
@@ -18,8 +18,8 @@
 #define IGNITION_MATH_GRAPH_GRAPH_HH_
 
 #include <cassert>
-#include <iostream>
 #include <map>
+#include <ostream>
 #include <set>
 #include <string>
 #include <utility>

--- a/include/ignition/math/graph/Vertex.hh
+++ b/include/ignition/math/graph/Vertex.hh
@@ -20,8 +20,8 @@
 // uint64_t
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <map>
+#include <ostream>
 #include <string>
 #include <utility>
 

--- a/src/SphericalCoordinates.cc
+++ b/src/SphericalCoordinates.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
 */
+#include <iostream>
 #include <string>
 
 #include "ignition/math/Matrix3.hh"


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The use of `<iostream>` induces global constructors in every translation unit to initialize `std::cout` and `std::cerr`.  We shouldn't do that unless we're actually going to use `std::cout` or `std::cerr`.

Reference: https://en.cppreference.com/w/cpp/header/iostream

## Checklist
- [x] Signed all commits for DCO
- [x] ~Added tests (N/A)~
- [x] ~Updated documentation (as needed)~
- [x] ~Updated migration guide (as needed)~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code)) -- no new errors; the 9 errors on the `main` branch are also reported on this PR.
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**