### PR TITLE
Defer Material::Predefined construction to avoid static initialization

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,9 @@
 1. Evict large function definitions from the Helpers.hh header file.
     * [Pull request 288](https://github.com/ignitionrobotics/ign-math/pull/288)
 
+1. Defer Material::Predefined construction to avoid static initialization.
+    * [Pull request 290](https://github.com/ignitionrobotics/ign-math/pull/290)
+
 ## Ignition Math 6.x
 
 ### Ignition Math 6.x.x

--- a/include/ignition/math/MaterialType.hh
+++ b/include/ignition/math/MaterialType.hh
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
 */
-#ifndef IGNITION_MATH_MATERIALTYPES_HH_
-#define IGNITION_MATH_MATERIALTYPES_HH_
+#ifndef IGNITION_MATH_MATERIALTYPE_HH_
+#define IGNITION_MATH_MATERIALTYPE_HH_
 
 #include <ignition/math/Export.hh>
 #include <ignition/math/config.hh>

--- a/src/MaterialType.hh
+++ b/src/MaterialType.hh
@@ -14,11 +14,11 @@
  * limitations under the License.
  *
 */
-#ifndef IGNITION_MATERIAL_HH_
-#define IGNITION_MATERIAL_HH_
+#ifndef IGNITION_MATH_SRC_MATERIAL_TYPE_HH_
+#define IGNITION_MATH_SRC_MATERIAL_TYPE_HH_
 
-#include <map>
-#include <string>
+#include <array>
+#include <utility>
 
 using namespace ignition;
 using namespace math;
@@ -27,17 +27,19 @@ using namespace math;
 struct MaterialData
 {
   // Name of the material
-  std::string name;
+  // cppcheck-suppress unusedStructMember
+  const char * const name;
 
   // Density of the material
   // cppcheck-suppress unusedStructMember
-  double density;
+  const double density;
 };
 
 // The mapping of material type to name and density values.
 // If you modify this map, make sure to also modify the MaterialType enum in
-// include/ignition/math/MaterialTypes.hh
-static std::map<MaterialType, MaterialData> kMaterialData =
+// include/ignition/math/MaterialTypes.hh. The compiler will also complain if
+// you forget to change the std::array<..., N> compile-time size constant.
+constexpr std::array<std::pair<MaterialType, MaterialData>, 13> kMaterialData =
 {{
   {MaterialType::STYROFOAM, {"styrofoam", 75.0}},
   {MaterialType::PINE, {"pine", 373.0}},


### PR DESCRIPTION
# 🦟 Bug fix

Mitigates a portion of #269.
Similar to #289.

## Summary

Defer Material::Predefined construction to avoid static initialization.
Switch the storage for the pre-defined list to be constexpr.
Also fix include guard spellings.

## Checklist
- [x] Signed all commits for DCO
- [x] ~Added tests (N/A)~
- [x] ~Updated documentation (as needed)~
- [x] ~Updated migration guide (as needed)~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
