### PR TITLE
Resolve cppcheck errors by adding explicit constructors and consts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,9 @@
 1. Evict large function definitions from the Helpers.hh header file.
     * [Pull request 288](https://github.com/ignitionrobotics/ign-math/pull/288)
 
+1. Resolve cppcheck errors by adding explicit constructors and consts.
+    * [Pull request 291](https://github.com/ignitionrobotics/ign-math/pull/291)
+
 ## Ignition Math 6.x
 
 ### Ignition Math 6.x.x

--- a/include/ignition/math/OrientedBox.hh
+++ b/include/ignition/math/OrientedBox.hh
@@ -131,7 +131,7 @@ namespace ignition
       /// \brief Set the box size.
       /// \param[in] _size Box size, in its own coordinate frame. Its absolute
       /// value will be taken, so the size is non-negative.
-      public: void Size(Vector3<T> &_size)
+      public: void Size(const Vector3<T> &_size)
       {
         // Enforce non-negative size
         this->size = _size.Abs();
@@ -139,7 +139,7 @@ namespace ignition
 
       /// \brief Set the box pose.
       /// \param[in] _pose Box pose.
-      public: void Pose(Pose3<T> &_pose)
+      public: void Pose(const Pose3<T> &_pose)
       {
         this->pose = _pose;
       }

--- a/include/ignition/math/Plane.hh
+++ b/include/ignition/math/Plane.hh
@@ -63,7 +63,7 @@ namespace ignition
       /// \brief Constructor from a normal and a distance
       /// \param[in] _normal The plane normal
       /// \param[in] _offset Offset along the normal
-      public: Plane(const Vector3<T> &_normal, T _offset = 0.0)
+      public: explicit Plane(const Vector3<T> &_normal, T _offset = 0.0)
       : normal(_normal), d(_offset)
       {
       }

--- a/include/ignition/math/SemanticVersion.hh
+++ b/include/ignition/math/SemanticVersion.hh
@@ -63,11 +63,11 @@ namespace ignition
       /// \param[in] _patch The patch number
       /// \param[in] _prerelease The prerelease string
       /// \param[in] _build The build metadata string
-      public: SemanticVersion(const unsigned int _major,
-                              const unsigned int _minor = 0,
-                              const unsigned int _patch = 0,
-                              const std::string &_prerelease = "",
-                              const std::string &_build = "");
+      public: explicit SemanticVersion(const unsigned int _major,
+                                       const unsigned int _minor = 0,
+                                       const unsigned int _patch = 0,
+                                       const std::string &_prerelease = "",
+                                       const std::string &_build = "");
 
       /// \brief Destructor
       public: ~SemanticVersion();

--- a/include/ignition/math/graph/Edge.hh
+++ b/include/ignition/math/graph/Edge.hh
@@ -47,6 +47,7 @@ namespace graph
     /// \param[in] _vertices The vertices of the edge.
     /// \param[in] _data The data stored in the edge.
     /// \param[in] _weight The weight (cost) of the edge.
+    // cppcheck-suppress noExplicitConstructor
     EdgeInitializer(const VertexId_P &_vertices,
                     const E &_data = E(),
                     const double _weight = 1)

--- a/include/ignition/math/graph/GraphAlgorithms.hh
+++ b/include/ignition/math/graph/GraphAlgorithms.hh
@@ -340,6 +340,7 @@ namespace graph
     // Add all vertices.
     for (auto const &vPair : _graph.Vertices())
     {
+      // cppcheck-suppress useStlAlgorithm
       vertices.push_back(vPair.second.get());
     }
 

--- a/include/ignition/math/graph/Vertex.hh
+++ b/include/ignition/math/graph/Vertex.hh
@@ -60,6 +60,7 @@ namespace graph
     /// \param[in] _name Non-unique vertex name.
     /// \param[in] _data User information.
     /// \param[in] _id Optional unique id.
+    // cppcheck-suppress noExplicitConstructor
     public: Vertex(const std::string &_name,
                    const V &_data = V(),
                    const VertexId _id = kNullId)

--- a/src/Frustum.cc
+++ b/src/Frustum.cc
@@ -156,6 +156,7 @@ bool Frustum::Contains(const Vector3d &_p) const
   // visible.
   for (auto const &plane : this->dataPtr->planes)
   {
+    // cppcheck-suppress useStlAlgorithm
     if (plane.Side(_p) == Planed::NEGATIVE_SIDE)
       return false;
   }

--- a/src/Kmeans_TEST.cc
+++ b/src/Kmeans_TEST.cc
@@ -48,7 +48,10 @@ TEST(KmeansTest, Kmeans)
 
   // ::SetObservations()
   for (auto &elem : obsCopy)
+  {
+    // cppcheck-suppress useStlAlgorithm
     elem += math::Vector3d(0.1, 0.2, 0.0);
+  }
 
   EXPECT_TRUE(kmeans.Observations(obsCopy));
 

--- a/src/Temperature_TEST.cc
+++ b/src/Temperature_TEST.cc
@@ -97,7 +97,6 @@ TEST(TemperatureTest, Operators)
   EXPECT_NEAR(temp(), 30, 1e-6);
 
   Temperature temp2 = temp;
-  // cppcheck-suppress knownConditionTrueFalse
   EXPECT_TRUE(temp == temp2);
 
   EXPECT_NEAR((temp + temp2).Kelvin(), 60, 1e-6);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes cppcheck complaints.

## Summary

At least for me on the head of the `main` branch, I see these errors:
```
jwnimmer@call-cps:~/jwnimmer-tri/build-ign-math/ign-math$ make codecheck

ign-math/include/ignition/math/Plane.hh:66:15: style: Class 'Plane' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
      public: Plane(const Vector3<T> &_normal, T _offset = 0.0)
              ^
ign-math/include/ignition/math/OrientedBox.hh:142:35: style: Parameter '_pose' can be declared with const [constParameter]
      public: void Pose(Pose3<T> &_pose)
                                  ^
ign-math/include/ignition/math/SemanticVersion.hh:66:15: style: Class 'SemanticVersion' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
      public: SemanticVersion(const unsigned int _major,
              ^
ign-math/include/ignition/math/graph/Edge.hh:50:5: style: Struct 'EdgeInitializer' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
    EdgeInitializer(const VertexId_P &_vertices,
    ^
ign-math/include/ignition/math/graph/Vertex.hh:63:13: style: Class 'Vertex' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
    public: Vertex(const std::string &_name,
            ^
ign-math/include/ignition/math/graph/GraphAlgorithms.hh:343:16: style: Consider using std::transform algorithm instead of a raw loop. [useStlAlgorithm]
      vertices.push_back(vPair.second.get());
               ^
ign-math/src/Frustum.cc:159:0: style: Consider using std::any_of algorithm instead of a raw loop. [useStlAlgorithm]
    if (plane.Side(_p) == Planed::NEGATIVE_SIDE)
^
ign-math/src/Kmeans_TEST.cc:51:10: style: Consider using std::transform algorithm instead of a raw loop. [useStlAlgorithm]
    elem += math::Vector3d(0.1, 0.2, 0.0);
         ^
ign-math/src/Temperature_TEST.cc:101:0: information: Unmatched suppression: knownConditionTrueFalse [unmatchedSuppression]
  EXPECT_TRUE(temp == temp2);
^
Built target cppcheck
```

This PR fixes all except the last one.

## Checklist
- [x] Signed all commits for DCO
- [x] ~Added tests (N/A)~
- [x] ~Updated documentation (as needed)~
- [x] ~Updated migration guide (as needed)~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

