### PR TITLE
Use constexpr for template static constants

### DIFF
--- a/include/ignition/math/Matrix3.hh
+++ b/include/ignition/math/Matrix3.hh
@@ -95,24 +95,26 @@ namespace ignition
     {
       /// \brief A Matrix3 initialized to identity.
       /// This is equivalent to math::Matrix3<T>(1, 0, 0, 0, 1, 0, 0, 0, 1).
-      public: static const Matrix3<T> Identity;
+      public: static constexpr Matrix3<T> Identity{
+        1, 0, 0,
+        0, 1, 0,
+        0, 0, 1};
 
       /// \brief A Matrix3 initialized to zero.
       /// This is equivalent to math::Matrix3<T>(0, 0, 0, 0, 0, 0, 0, 0, 0).
-      public: static const Matrix3<T> Zero;
+      public: static constexpr Matrix3<T> Zero{};
 
       /// \brief Default constructor that initializes the matrix3 to zero.
-      public: Matrix3()
+      public: constexpr Matrix3()
+      : data{{0, 0, 0},
+             {0, 0, 0},
+             {0, 0, 0}}
       {
-        std::memset(this->data, 0, sizeof(this->data[0][0])*9);
       }
 
       /// \brief Copy constructor.
       /// \param _m Matrix to copy
-      public: Matrix3(const Matrix3<T> &_m)
-      {
-        std::memcpy(this->data, _m.data, sizeof(this->data[0][0])*9);
-      }
+      public: Matrix3(const Matrix3<T> &_m) = default;
 
       /// \brief Construct a matrix3 using nine values.
       /// \param[in] _v00 Row 0, Col 0 value
@@ -124,19 +126,13 @@ namespace ignition
       /// \param[in] _v20 Row 2, Col 0 value
       /// \param[in] _v21 Row 2, Col 1 value
       /// \param[in] _v22 Row 2, Col 2 value
-      public: Matrix3(T _v00, T _v01, T _v02,
-                      T _v10, T _v11, T _v12,
-                      T _v20, T _v21, T _v22)
+      public: constexpr Matrix3(T _v00, T _v01, T _v02,
+                                T _v10, T _v11, T _v12,
+                                T _v20, T _v21, T _v22)
+      : data{{_v00, _v01, _v02},
+             {_v10, _v11, _v12},
+             {_v20, _v21, _v22}}
       {
-        this->data[0][0] = _v00;
-        this->data[0][1] = _v01;
-        this->data[0][2] = _v02;
-        this->data[1][0] = _v10;
-        this->data[1][1] = _v11;
-        this->data[1][2] = _v12;
-        this->data[2][0] = _v20;
-        this->data[2][1] = _v21;
-        this->data[2][2] = _v22;
       }
 
       /// \brief Construct 3x3 rotation Matrix from a quaternion.
@@ -157,7 +153,7 @@ namespace ignition
       }
 
       /// \brief Desctructor
-      public: ~Matrix3() {}
+      public: ~Matrix3() = default;
 
       /// \brief Set a single value.
       /// \param[in] _row row index. _row is clamped to the range [0,2]
@@ -333,11 +329,7 @@ namespace ignition
       /// \brief Equal operator. this = _mat
       /// \param _mat Matrix to copy.
       /// \return This matrix.
-      public: Matrix3<T> &operator=(const Matrix3<T> &_mat)
-      {
-        memcpy(this->data, _mat.data, sizeof(this->data[0][0])*9);
-        return *this;
-      }
+      public: Matrix3<T> &operator=(const Matrix3<T> &_mat) = default;
 
       /// \brief Subtraction operator.
       /// \param[in] _m Matrix to subtract.
@@ -648,18 +640,6 @@ namespace ignition
       /// \brief the 3x3 matrix
       private: T data[3][3];
     };
-
-    template<typename T>
-    const Matrix3<T> Matrix3<T>::Identity(
-        1, 0, 0,
-        0, 1, 0,
-        0, 0, 1);
-
-    template<typename T>
-    const Matrix3<T> Matrix3<T>::Zero(
-        0, 0, 0,
-        0, 0, 0,
-        0, 0, 0);
 
     /// typedef Matrix3<int> as Matrix3i.
     typedef Matrix3<int> Matrix3i;

--- a/include/ignition/math/Matrix4.hh
+++ b/include/ignition/math/Matrix4.hh
@@ -38,23 +38,27 @@ namespace ignition
     class Matrix4
     {
       /// \brief Identity matrix
-      public: static const Matrix4<T> Identity;
+      public: static constexpr Matrix4<T> Identity{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1};
 
       /// \brief Zero matrix
-      public: static const Matrix4<T> Zero;
+      public: static constexpr Matrix4<T> Zero{};
 
       /// \brief Constructor
-      public: Matrix4()
+      public: constexpr Matrix4()
+      : data{{0, 0, 0, 0},
+             {0, 0, 0, 0},
+             {0, 0, 0, 0},
+             {0, 0, 0, 0}}
       {
-        memset(this->data, 0, sizeof(this->data[0][0])*16);
       }
 
       /// \brief Copy constructor
       /// \param _m Matrix to copy
-      public: Matrix4(const Matrix4<T> &_m)
-      {
-        memcpy(this->data, _m.data, sizeof(this->data[0][0])*16);
-      }
+      public: Matrix4(const Matrix4<T> &_m) = default;
 
       /// \brief Constructor
       /// \param[in] _v00 Row 0, Col 0 value
@@ -73,15 +77,15 @@ namespace ignition
       /// \param[in] _v31 Row 3, Col 1 value
       /// \param[in] _v32 Row 3, Col 2 value
       /// \param[in] _v33 Row 3, Col 3 value
-      public: Matrix4(T _v00, T _v01, T _v02, T _v03,
-                      T _v10, T _v11, T _v12, T _v13,
-                      T _v20, T _v21, T _v22, T _v23,
-                      T _v30, T _v31, T _v32, T _v33)
+      public: constexpr Matrix4(T _v00, T _v01, T _v02, T _v03,
+                                T _v10, T _v11, T _v12, T _v13,
+                                T _v20, T _v21, T _v22, T _v23,
+                                T _v30, T _v31, T _v32, T _v33)
+      : data{{_v00, _v01, _v02, _v03},
+             {_v10, _v11, _v12, _v13},
+             {_v20, _v21, _v22, _v23},
+             {_v30, _v31, _v32, _v33}}
       {
-        this->Set(_v00, _v01, _v02, _v03,
-                  _v10, _v11, _v12, _v13,
-                  _v20, _v21, _v22, _v23,
-                  _v30, _v31, _v32, _v33);
       }
 
       /// \brief Construct Matrix4 from a quaternion.
@@ -116,7 +120,7 @@ namespace ignition
       }
 
       /// \brief Destructor
-      public: virtual ~Matrix4() {}
+      public: ~Matrix4() = default;
 
       /// \brief Change the values
       /// \param[in] _v00 Row 0, Col 0 value
@@ -547,11 +551,7 @@ namespace ignition
       /// \brief Equal operator. this = _mat
       /// \param _mat Incoming matrix
       /// \return itself
-      public: Matrix4<T> &operator=(const Matrix4<T> &_mat)
-      {
-        memcpy(this->data, _mat.data, sizeof(this->data[0][0])*16);
-        return *this;
-      }
+      public: Matrix4<T> &operator=(const Matrix4<T> &_mat) = default;
 
       /// \brief Equal operator for 3x3 matrix
       /// \param _mat Incoming matrix
@@ -850,20 +850,6 @@ namespace ignition
       /// \brief The 4x4 matrix
       private: T data[4][4];
     };
-
-    template<typename T>
-    const Matrix4<T> Matrix4<T>::Identity(
-        1, 0, 0, 0,
-        0, 1, 0, 0,
-        0, 0, 1, 0,
-        0, 0, 0, 1);
-
-    template<typename T>
-    const Matrix4<T> Matrix4<T>::Zero(
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-        0, 0, 0, 0);
 
     typedef Matrix4<int> Matrix4i;
     typedef Matrix4<double> Matrix4d;

--- a/include/ignition/math/Pose3.hh
+++ b/include/ignition/math/Pose3.hh
@@ -74,7 +74,7 @@ namespace ignition
     {
       /// \brief A Pose3 initialized to zero.
       /// This is equivalent to math::Pose3<T>(0, 0, 0, 0, 0, 0).
-      public: static const Pose3<T> Zero;
+      public: static constexpr Pose3<T> Zero{};
 
       /// \brief Default constructor. This initializes the position
       /// component to zero and the quaternion to identity.
@@ -118,13 +118,10 @@ namespace ignition
 
       /// \brief Copy constructor.
       /// \param[in] _pose Pose3<T> to copy
-      public: Pose3(const Pose3<T> &_pose)
-      : p(_pose.p), q(_pose.q)
-      {
-      }
+      public: Pose3(const Pose3<T> &_pose) = default;
 
       /// \brief Destructor.
-      public: ~Pose3() {}
+      public: ~Pose3() = default;
 
       /// \brief Set the pose from a Vector3<T> and a Quaternion<T>
       /// \param[in] _pos The position.
@@ -280,12 +277,7 @@ namespace ignition
 
       /// \brief Assignment operator
       /// \param[in] _pose Pose3<T> to copy
-      public: Pose3<T> &operator=(const Pose3<T> &_pose)
-      {
-        this->p = _pose.p;
-        this->q = _pose.q;
-        return *this;
-      }
+      public: Pose3<T> &operator=(const Pose3<T> &_pose) = default;
 
       /// \brief Add one point to a vector: result = this + pos.
       /// \param[in] _pos Position to add to this pose
@@ -547,8 +539,6 @@ namespace ignition
       /// \brief The rotation
       private: Quaternion<T> q;
     };
-
-    template<typename T> const Pose3<T> Pose3<T>::Zero(0, 0, 0, 0, 0, 0);
 
     /// typedef Pose3<double> as Pose3d.
     typedef Pose3<double> Pose3d;

--- a/include/ignition/math/Quaternion.hh
+++ b/include/ignition/math/Quaternion.hh
@@ -81,14 +81,14 @@ namespace ignition
     {
       /// \brief A Quaternion initialized to identity.
       /// This is equivalent to math::Quaternion<T>(1, 0, 0, 0)
-      public: static const Quaternion Identity;
+      public: static constexpr Quaternion Identity{};
 
       /// \brief A Quaternion initialized to zero.
       /// This is equivalent to math::Quaternion<T>(0, 0, 0, 0)
-      public: static const Quaternion Zero;
+      public: static constexpr Quaternion Zero{0, 0, 0, 0};
 
       /// \brief Default Constructor
-      public: Quaternion()
+      public: constexpr Quaternion()
       : qw(1), qx(0), qy(0), qz(0)
       {
         // quaternion not normalized, because that breaks
@@ -102,7 +102,8 @@ namespace ignition
       /// \param[in] _x X param
       /// \param[in] _y Y param
       /// \param[in] _z Z param
-      public: Quaternion(const T &_w, const T &_x, const T &_y, const T &_z)
+      public: constexpr Quaternion(const T &_w, const T &_x, const T &_y,
+                                   const T &_z)
       : qw(_w), qx(_x), qy(_y), qz(_z)
       {}
 
@@ -146,28 +147,14 @@ namespace ignition
       /// \brief Copy constructor. This constructor does not normalize the
       /// quaternion.
       /// \param[in] _qt Quaternion<T> to copy
-      public: Quaternion(const Quaternion<T> &_qt)
-      {
-        this->qw = _qt.qw;
-        this->qx = _qt.qx;
-        this->qy = _qt.qy;
-        this->qz = _qt.qz;
-      }
+      public: Quaternion(const Quaternion<T> &_qt) = default;
 
       /// \brief Destructor
-      public: ~Quaternion() {}
+      public: ~Quaternion() = default;
 
       /// \brief Assignment operator
       /// \param[in] _qt Quaternion<T> to copy
-      public: Quaternion<T> &operator=(const Quaternion<T> &_qt)
-      {
-        this->qw = _qt.qw;
-        this->qx = _qt.qx;
-        this->qy = _qt.qy;
-        this->qz = _qt.qz;
-
-        return *this;
-      }
+      public: Quaternion<T> &operator=(const Quaternion<T> &_qt) = default;
 
       /// \brief Invert the quaternion. The quaternion is first normalized,
       /// then inverted.
@@ -1269,12 +1256,6 @@ namespace ignition
       /// \brief z value of the quaternion
       private: T qz;
     };
-
-    template<typename T> const Quaternion<T>
-      Quaternion<T>::Identity(1, 0, 0, 0);
-
-    template<typename T> const Quaternion<T>
-      Quaternion<T>::Zero(0, 0, 0, 0);
 
     /// typedef Quaternion<double> as Quaterniond
     typedef Quaternion<double> Quaterniond;

--- a/include/ignition/math/Vector2.hh
+++ b/include/ignition/math/Vector2.hh
@@ -35,37 +35,31 @@ namespace ignition
     class Vector2
     {
       /// \brief math::Vector2(0, 0)
-      public: static const Vector2<T> Zero;
+      public: static constexpr Vector2<T> Zero{};
 
       /// \brief math::Vector2(1, 1)
-      public: static const Vector2<T> One;
+      public: static constexpr Vector2<T> One{1, 1};
 
       /// \brief Default Constructor
-      public: Vector2()
+      public: constexpr Vector2()
+      : data{0, 0}
       {
-        this->data[0] = 0;
-        this->data[1] = 0;
       }
 
       /// \brief Constructor
       /// \param[in] _x value along x
       /// \param[in] _y value along y
-      public: Vector2(const T &_x, const T &_y)
+      public: constexpr Vector2(const T &_x, const T &_y)
+      : data{_x, _y}
       {
-        this->data[0] = _x;
-        this->data[1] = _y;
       }
 
       /// \brief Copy constructor
       /// \param[in] _v the value
-      public: Vector2(const Vector2<T> &_v)
-      {
-        this->data[0] = _v[0];
-        this->data[1] = _v[1];
-      }
+      public: constexpr Vector2(const Vector2<T> &_v) = default;
 
       /// \brief Destructor
-      public: virtual ~Vector2() {}
+      public: ~Vector2() = default;
 
       /// \brief Return the sum of the values
       /// \return the sum
@@ -222,13 +216,7 @@ namespace ignition
       /// \brief Assignment operator
       /// \param[in] _v a value for x and y element
       /// \return this
-      public: Vector2 &operator=(const Vector2 &_v)
-      {
-        this->data[0] = _v[0];
-        this->data[1] = _v[1];
-
-        return *this;
-      }
+      public: Vector2 &operator=(const Vector2 &_v) = default;
 
       /// \brief Assignment operator
       /// \param[in] _v the value for x and y element
@@ -574,12 +562,6 @@ namespace ignition
       /// \brief The x and y values.
       private: T data[2];
     };
-
-    template<typename T>
-    const Vector2<T> Vector2<T>::Zero(0, 0);
-
-    template<typename T>
-    const Vector2<T> Vector2<T>::One(1, 1);
 
     typedef Vector2<int> Vector2i;
     typedef Vector2<double> Vector2d;

--- a/include/ignition/math/Vector3.hh
+++ b/include/ignition/math/Vector3.hh
@@ -40,50 +40,41 @@ namespace ignition
     class Vector3
     {
       /// \brief math::Vector3(0, 0, 0)
-      public: static const Vector3 Zero;
+      public: static constexpr Vector3 Zero{};
 
       /// \brief math::Vector3(1, 1, 1)
-      public: static const Vector3 One;
+      public: static constexpr Vector3 One{1, 1, 1};
 
       /// \brief math::Vector3(1, 0, 0)
-      public: static const Vector3 UnitX;
+      public: static constexpr Vector3 UnitX{1, 0, 0};
 
       /// \brief math::Vector3(0, 1, 0)
-      public: static const Vector3 UnitY;
+      public: static constexpr Vector3 UnitY{0, 1, 0};
 
       /// \brief math::Vector3(0, 0, 1)
-      public: static const Vector3 UnitZ;
+      public: static constexpr Vector3 UnitZ{0, 0, 1};
 
       /// \brief Constructor
-      public: Vector3()
+      public: constexpr Vector3()
+      : data{0, 0, 0}
       {
-        this->data[0] = 0;
-        this->data[1] = 0;
-        this->data[2] = 0;
       }
 
       /// \brief Constructor
       /// \param[in] _x value along x
       /// \param[in] _y value along y
       /// \param[in] _z value along z
-      public: Vector3(const T &_x, const T &_y, const T &_z)
+      public: constexpr Vector3(const T &_x, const T &_y, const T &_z)
+      : data{_x, _y, _z}
       {
-        this->data[0] = _x;
-        this->data[1] = _y;
-        this->data[2] = _z;
       }
 
       /// \brief Copy constructor
       /// \param[in] _v a vector
-      public: Vector3(const Vector3<T> &_v)
-      {
-        this->data[0] = _v[0];
-        this->data[1] = _v[1];
-        this->data[2] = _v[2];
-      }
+      public: Vector3(const Vector3<T> &_v) = default;
 
       /// \brief Destructor
-      public: virtual ~Vector3() {}
+      public: ~Vector3() = default;
 
       /// \brief Return the sum of the values
       /// \return the sum
@@ -330,14 +321,7 @@ namespace ignition
       /// \brief Assignment operator
       /// \param[in] _v a new value
       /// \return this
-      public: Vector3 &operator=(const Vector3<T> &_v)
-      {
-        this->data[0] = _v[0];
-        this->data[1] = _v[1];
-        this->data[2] = _v[2];
-
-        return *this;
-      }
+      public: Vector3 &operator=(const Vector3<T> &_v) = default;
 
       /// \brief Assignment operator
       /// \param[in] _v assigned to all elements
@@ -770,12 +754,6 @@ namespace ignition
       /// \brief The x, y, and z values
       private: T data[3];
     };
-
-    template<typename T> const Vector3<T> Vector3<T>::Zero(0, 0, 0);
-    template<typename T> const Vector3<T> Vector3<T>::One(1, 1, 1);
-    template<typename T> const Vector3<T> Vector3<T>::UnitX(1, 0, 0);
-    template<typename T> const Vector3<T> Vector3<T>::UnitY(0, 1, 0);
-    template<typename T> const Vector3<T> Vector3<T>::UnitZ(0, 0, 1);
 
     typedef Vector3<int> Vector3i;
     typedef Vector3<double> Vector3d;

--- a/include/ignition/math/Vector4.hh
+++ b/include/ignition/math/Vector4.hh
@@ -36,15 +36,15 @@ namespace ignition
     class Vector4
     {
       /// \brief math::Vector4(0, 0, 0, 0)
-      public: static const Vector4<T> Zero;
+      public: static constexpr Vector4<T> Zero{};
 
       /// \brief math::Vector4(1, 1, 1, 1)
-      public: static const Vector4<T> One;
+      public: static constexpr Vector4<T> One{1, 1, 1, 1};
 
       /// \brief Constructor
-      public: Vector4()
+      public: constexpr Vector4()
+      : data{0, 0, 0, 0}
       {
-        this->data[0] = this->data[1] = this->data[2] = this->data[3] = 0;
       }
 
       /// \brief Constructor with component values
@@ -52,26 +52,18 @@ namespace ignition
       /// \param[in] _y value along y axis
       /// \param[in] _z value along z axis
       /// \param[in] _w value along w axis
-      public: Vector4(const T &_x, const T &_y, const T &_z, const T &_w)
+      public: constexpr Vector4(const T &_x, const T &_y, const T &_z,
+                                const T &_w)
+      : data{_x, _y, _z, _w}
       {
-        this->data[0] = _x;
-        this->data[1] = _y;
-        this->data[2] = _z;
-        this->data[3] = _w;
       }
 
       /// \brief Copy constructor
       /// \param[in] _v vector
-      public: Vector4(const Vector4<T> &_v)
-      {
-        this->data[0] = _v[0];
-        this->data[1] = _v[1];
-        this->data[2] = _v[2];
-        this->data[3] = _v[3];
-      }
+      public: Vector4(const Vector4<T> &_v) = default;
 
       /// \brief Destructor
-      public: virtual ~Vector4() {}
+      public: ~Vector4() = default;
 
       /// \brief Calc distance to the given point
       /// \param[in] _pt the point
@@ -264,15 +256,7 @@ namespace ignition
       /// \brief Assignment operator
       /// \param[in] _v the vector
       /// \return a reference to this vector
-      public: Vector4<T> &operator=(const Vector4<T> &_v)
-      {
-        this->data[0] = _v[0];
-        this->data[1] = _v[1];
-        this->data[2] = _v[2];
-        this->data[3] = _v[3];
-
-        return *this;
-      }
+      public: Vector4<T> &operator=(const Vector4<T> &_v) = default;
 
       /// \brief Assignment operator
       /// \param[in] _value
@@ -729,12 +713,6 @@ namespace ignition
       /// \brief Data values, 0==x, 1==y, 2==z, 3==w
       private: T data[4];
     };
-
-    template<typename T>
-    const Vector4<T> Vector4<T>::Zero(0, 0, 0, 0);
-
-    template<typename T>
-    const Vector4<T> Vector4<T>::One(1, 1, 1, 1);
 
     typedef Vector4<int> Vector4i;
     typedef Vector4<double> Vector4d;


### PR DESCRIPTION
# 🦟 Bug fix

A portion of #269.

## Summary

Use constexpr for simple static constants, to avoid the C++ global static construction and destruction order fiascos.
Remove virtual from destructors of affected classes.
Switch any rule-of-5 functions to be defaulted.

## Checklist
- [x] Signed all commits for DCO
- [x] ~Added tests (N/A)~
- [x] ~Updated documentation (as needed)~
- [x] ~Updated migration guide (as needed)~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
