### PR TITLE
Speed up Helpers::Pair test

### DIFF
--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -501,9 +501,13 @@ TEST(HelpersTest, Pair)
 
 #if !defined _MSC_VER && !defined __arm__
     // Iterate over large numbers, and check for unique keys.
-    for (math::PairInput a = math::MAX_UI32-5000; a < math::MAX_UI32; a++)
+    for (math::PairInput a = math::MAX_UI32 - 10000;
+         a < math::MAX_UI32 - 500;
+         a += math::Rand::IntUniform(100, 500))
     {
-      for (math::PairInput b = math::MAX_UI32-5000; b < math::MAX_UI32; b++)
+      for (math::PairInput b = math::MAX_UI32 - 10000;
+           b < math::MAX_UI32 - 500;
+           b += math::Rand::IntUniform(100, 500))
       {
         math::PairOutput key = math::Pair(a, b);
         std::tie(c, d) = math::Unpair(key);
@@ -514,6 +518,8 @@ TEST(HelpersTest, Pair)
         set.insert(key);
       }
     }
+
+    std::cout << "Tested: " << set.size() << " keys\n.";
 #endif
   }
 }

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -518,8 +518,6 @@ TEST(HelpersTest, Pair)
         set.insert(key);
       }
     }
-
-    std::cout << "Tested: " << set.size() << " keys\n.";
 #endif
   }
 }


### PR DESCRIPTION
Housekeeping on the `math::Pair` unittest.

I'm not sure that exhaustively testing this many pairs is worthwhile, in general.

On my system (before):

```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from HelpersTest
[ RUN      ] HelpersTest.Pair
Tested: 25048098 keys 
[       OK ] HelpersTest.Pair (5872 ms)
[----------] 1 test from HelpersTest (5872 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (5872 ms total)
[  PASSED  ] 1 test.
./bin/UNIT_Helpers_TEST --gtest_filter="*.Pair"  5.66s user 0.26s system 99% cpu 5.935 total
```

(after):
```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from HelpersTest
[ RUN      ] HelpersTest.Pair
Tested: 46829 keys
.[       OK ] HelpersTest.Pair (9 ms)
[----------] 1 test from HelpersTest (9 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (9 ms total)
[  PASSED  ] 1 test.
./bin/UNIT_Helpers_TEST --gtest_filter="*.Pair"  0.01s user 0.00s system 96% cpu 0.016 total
```

I believe that @nkoenig and @scpeters were the ones who most recently touched this function, so pinging them for reviews.

Signed-off-by: Michael Carroll <michael@openrobotics.org>

**Note to maintainers**: Remember to use **Squash-Merge**