### PR TITLE
Ubuntu Jammy CI

### DIFF
--- a/.github/ci/packages-bionic.apt
+++ b/.github/ci/packages-bionic.apt
@@ -1,0 +1,1 @@
+libignition-cmake2-dev

--- a/.github/ci/packages-focal.apt
+++ b/.github/ci/packages-focal.apt
@@ -1,0 +1,1 @@
+libignition-cmake2-dev

--- a/.github/ci/packages-jammy.apt
+++ b/.github/ci/packages-jammy.apt
@@ -1,0 +1,1 @@
+libignition-cmake-dev

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,4 +1,3 @@
 libeigen3-dev
-libignition-cmake2-dev
 ruby-dev
 swig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,12 @@ jobs:
       - name: Compile and test
         id: ci
         uses: ignition-tooling/action-ignition-ci@focal
+  jammy-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Jammy CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compile and test
+        id: ci
+        uses: ignition-tooling/action-ignition-ci@jammy


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Enable Jammy CI so we can test using the latest tooling.

One downside of doing it this early is that we don't have Jammy packages on https://packages.osrfoundation.org yet, so we have to rely on the upstream version of `ign-cmake`. Because the upstream package has a different name, that forces us to split the dependencies for Bionic / Focal / Jammy. Once we have `libignition-cmake2-dev` on our repo, I think we should use that on CI and revert the changes to `packages*.apt`.

That's to say I'm not convinced it's a good idea to merge this PR now, but I thought I'd open it to start a conversation.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

See CI results.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] ~~Added example and/or tutorial~~
- [x] ~~Updated documentation (as needed)~~
- [x] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
