### PR TITLE
Document that euler angles should be in radians for quaternion constructor

### DIFF
--- a/include/ignition/math/Quaternion.hh
+++ b/include/ignition/math/Quaternion.hh
@@ -78,7 +78,7 @@ namespace ignition
       }
 
       /// \brief Constructor
-      /// \param[in] _rpy euler angles
+      /// \param[in] _rpy euler angles, in radians
       public: explicit Quaternion(const Vector3<T> &_rpy)
       {
         this->Euler(_rpy);


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

## Summary
To help remove confusion for users, I added a note that the quaternion constructor that takes a euler angle vector expects the angles to be in radians.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**