### PR TITLE
Fix Focal on Jenkins

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,5 +1,6 @@
 libeigen3-dev
 libignition-cmake2-dev
+python3-distutils
+python3-pybind11
 ruby-dev
 swig
-python3-pybind11

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
+project(ignition-math-examples)
+
 # Find the Ignition-Math library
 set(IGN_MATH_VER 6)
 find_package(ignition-math${IGN_MATH_VER} REQUIRED)


### PR DESCRIPTION
# 🦟 Bug fix

* Alternative to https://github.com/ignition-tooling/release-tools/pull/621
* Broken off https://github.com/ignitionrobotics/ign-math/pull/360

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

`ign-math` builds have been failing on Jenkins since we migrated to Focal in https://github.com/ignition-tooling/release-tools/pull/565

As @j-rivero found out, adding the `python3-distutils` dependency fixes the build.

I haven't looked into why this extra dependency is needed by Jenkins but not by GitHub actions, which has been successfully building Python bindings without this dependency on Focal. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
