### PR TITLE
Use const instead of constexpr in Ellipsoid constructor

### DIFF
--- a/include/ignition/math/detail/Ellipsoid.hh
+++ b/include/ignition/math/detail/Ellipsoid.hh
@@ -96,7 +96,7 @@ std::optional< MassMatrix3<T> > Ellipsoid<T>::MassMatrix() const
 template<typename T>
 T Ellipsoid<T>::Volume() const
 {
-  constexpr T kFourThirdsPi = 4. * IGN_PI / 3.;
+  const T kFourThirdsPi = 4. * IGN_PI / 3.;
   return kFourThirdsPi * this->radii.X() * this->radii.Y() * this->radii.Z();
 }
 


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
While working on https://github.com/ignitionrobotics/sdformat/pull/821, I had the following build error:
```
In file included from /usr/include/ignition/math6/ignition/math/Ellipsoid.hh:132:0,
                 from /sdf_to_usd/src/sdformat/include/sdf/Ellipsoid.hh:20,
                 from /sdf_to_usd/src/sdformat/src/Ellipsoid_TEST.cc:19:
/usr/include/ignition/math6/ignition/math/detail/Ellipsoid.hh: In instantiation of 'T ignition::math::v6::Ellipsoid<Precision>::Volume() const [with Precision = double]':
/sdf_to_usd/src/sdformat/src/Ellipsoid_TEST.cc:27:3:   required from here
/usr/include/ignition/math6/ignition/math/detail/Ellipsoid.hh:99:43: error: '(1.2566370614359172e+1 / 3.0e+0)' is not a constant expression
   constexpr T kFourThirdsPi = 4. * IGN_PI / 3.;
```

I believe the issue is with `IGN_PI`. It is [defined as a floating point value](https://github.com/ignitionrobotics/ign-math/blob/ignition-math6_6.9.3-pre1/include/ignition/math/Helpers.hh#L176-L188), but the c++ standard says the following ([source](https://en.cppreference.com/w/cpp/language/constant_expression#Usable_in_constant_expressions)):
```
a variable is usable in constant expressions at a point P if the variable is: 
- a constexpr variable, or
- it is a constant-initialized variable
    - of reference type or
    - of const-qualified integral or enumeration type
```

So, since `IGN_PI` is not a const-qualified integral/enumeration type, I believe this is causing an error in the sdformat ellipsoid unit test (I'm not sure why this hasn't been an issue until now, though).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.