### PR TITLE
🎈 6.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-math6 VERSION 6.9.3)
+project(ignition-math6 VERSION 6.10.0)
 
 #============================================================================
 # Find ignition-cmake
@@ -16,7 +16,7 @@ find_package(ignition-cmake2 2.8.0 REQUIRED)
 #============================================================================
 set (c++standard 17)
 set (CMAKE_CXX_STANDARD 17)
-ign_configure_project(VERSION_SUFFIX pre2)
+ign_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Ignition Math 6.x.x
 
-## Ignition Math 6.10.0 (2022-01-25)
+## Ignition Math 6.10.0 (2022-01-26)
 
 1. Use const instead of constexpr in Ellipsoid constructor
     * [Pull request #366](https://github.com/ignitionrobotics/ign-math/pull/366)
@@ -49,6 +49,7 @@
         * [Pull request #337](https://github.com/ignitionrobotics/ign-math/pull/337)
     1. PID
         * [Pull request #323](https://github.com/ignitionrobotics/ign-math/pull/323)
+        * [Pull request #361](https://github.com/ignitionrobotics/ign-math/pull/361)
     1. Temperature
         * [Pull request #330](https://github.com/ignitionrobotics/ign-math/pull/330)
     1. DiffDriveOdometry (with examples)
@@ -86,6 +87,7 @@
         * [Pull request #317](https://github.com/ignitionrobotics/ign-math/pull/317)
     1. Quaternion
         * [Pull request #324](https://github.com/ignitionrobotics/ign-math/pull/324)
+        * [Pull request #361](https://github.com/ignitionrobotics/ign-math/pull/361)
     1. StopWatch
         * [Pull request #319](https://github.com/ignitionrobotics/ign-math/pull/319)
     1. RollingMean

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Ignition Math 6.x.x
 
-## Ignition Math 6.9.3 (2022-01-XX)
+## Ignition Math 6.10.0 (2022-01-25)
 
 1. Use const instead of constexpr in Ellipsoid constructor
     * [Pull request #366](https://github.com/ignitionrobotics/ign-math/pull/366)


### PR DESCRIPTION
# 🎈 Release

Prepare for 6.10.0 release.

Comparison to 6.9.2: https://github.com/ignitionrobotics/ign-math/compare/ignition-math6_6.9.2...ign-math6

This follows the 6.9.3~pre2 pre-release:

* https://github.com/ignitionrobotics/ign-math/pull/367

Various updates have been made to packaging too:

* https://github.com/ignition-release/ign-math6-release/pull/7
* https://github.com/ignition-release/ign-math6-release/pull/8
* https://github.com/ignition-release/ign-math6-release/pull/9

I think we're in a good point to call our Python interfaces a feature, that's why I bumped the minor instead of the patch version.

Required by

* https://github.com/ignitionrobotics/ign-gazebo/pull/1219

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [x] Updated migration guide (as needed)
- [x] ~~Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed): <LINK>~~

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
