### PR TITLE
Reduce memory required to compile pybind11 interface

### DIFF
--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -28,6 +28,7 @@ pybind11_add_module(math SHARED
   src/Spline.cc
   src/StopWatch.cc
   src/Temperature.cc
+  src/Vector2.cc
   src/Vector3Stats.cc
 )
 

--- a/src/python_pybind11/src/Angle.cc
+++ b/src/python_pybind11/src/Angle.cc
@@ -17,6 +17,7 @@
 
 #include <string>
 
+#include <ignition/math/Angle.hh>
 #include <pybind11/operators.h>
 
 #include "Angle.hh"

--- a/src/python_pybind11/src/Angle.hh
+++ b/src/python_pybind11/src/Angle.hh
@@ -21,8 +21,6 @@
 
 #include <pybind11/pybind11.h>
 
-#include <ignition/math/Angle.hh>
-
 namespace py = pybind11;
 
 namespace ignition

--- a/src/python_pybind11/src/Vector2.cc
+++ b/src/python_pybind11/src/Vector2.cc
@@ -17,13 +17,7 @@
 
 #include <string>
 
-#include <ignition/math/Vector2.hh>
-#include <pybind11/pybind11.h>
-#include <pybind11/operators.h>
-
 #include "Vector2.hh"
-
-using namespace pybind11::literals;
 
 namespace ignition
 {
@@ -31,105 +25,6 @@ namespace math
 {
 namespace python
 {
-/// Template helper function
-template<typename T>
-void helpDefineMathVector2(py::module &m, const std::string &typestr)
-{
-  using Class = ignition::math::Vector2<T>;
-  auto toString = [](const Class &si) {
-    std::stringstream stream;
-    stream << si;
-    return stream.str();
-  };
-  std::string pyclass_name = typestr;
-  py::class_<Class>(m,
-                    pyclass_name.c_str(),
-                    py::buffer_protocol(),
-                    py::dynamic_attr())
-    .def(py::init<>())
-    .def(py::init<const T&, const T&>())
-    .def(py::init<const Class>())
-    .def("sum", &Class::Sum, "Return the sum of the values")
-    .def("distance", &Class::Distance, "Calc distance to the given point")
-    .def("length",
-         &Class::Length,
-         "Returns the length (magnitude) of the vector")
-    .def("squared_length",
-         &Class::SquaredLength,
-         "Return the square of the length (magnitude) of the vector")
-    .def("normalize", &Class::Normalize, "Normalize the vector length")
-    .def("normalized", &Class::Normalized, "Return a normalized vector")
-    .def("round",
-         &Class::Round,
-         "Round to near whole number, return the result.")
-    .def("rounded", &Class::Rounded, "Get a rounded version of this vector")
-    .def("set", &Class::Set, "Set the contents of the vector")
-    .def("dot",
-         &Class::Dot,
-         "Return the dot product of this vector and another vector")
-    .def("abs_dot", &Class::AbsDot,
-        "Return the absolute dot product of this vector and "
-        "another vector. This is similar to the Dot function, except the "
-        "absolute value of each component of the vector is used.")
-    .def("abs",
-         &Class::Abs,
-         "Get the absolute value of the vector")
-    .def("max",
-         py::overload_cast<const Class&>(&Class::Max),
-         "Set this vector's components to the maximum of itself and the "
-         "passed in vector")
-    .def("max", py::overload_cast<>(&Class::Max, py::const_),
-         "Get the maximum value in the vector")
-    .def("min", py::overload_cast<const Class&>(&Class::Min),
-         "Set this vector's components to the minimum of itself and the "
-         "passed in vector")
-    .def("min", py::overload_cast<>(&Class::Min, py::const_),
-         "Get the minimum value in the vector")
-    .def(py::self + py::self)
-    .def(py::self += py::self)
-    .def(py::self + T())
-    .def(py::self += T())
-    .def(py::self * py::self)
-    .def(py::self *= py::self)
-    .def(py::self * T())
-    .def(py::self *= T())
-    .def(py::self - py::self)
-    .def(py::self -= py::self)
-    .def(py::self - T())
-    .def(py::self -= T())
-    .def(py::self / py::self)
-    .def(py::self /= py::self)
-    .def(py::self / T())
-    .def(py::self /= T())
-    .def(py::self != py::self)
-    .def(py::self == py::self)
-    .def(-py::self)
-    .def("equal", &Class::Equal, "Equal to operator")
-    .def("is_finite",
-         &Class::IsFinite,
-         "See if a point is finite (e.g., not nan)")
-    .def("correct", &Class::Correct, "Corrects any nan values")
-    .def("x", py::overload_cast<>(&Class::X), "Get the x value.")
-    .def("y", py::overload_cast<>(&Class::Y), "Get the y value.")
-    .def("x", py::overload_cast<const T&>(&Class::X), "Set the x value.")
-    .def("y", py::overload_cast<const T&>(&Class::Y), "Set the y value.")
-    .def_readonly_static("ZERO", &Class::Zero, "math::Vector2(0, 0)")
-    .def_readonly_static("ONE", &Class::One, "math::Vector2(1, 1)")
-    .def_readonly_static("NAN", &Class::NaN, "math::Vector3(NaN, NaN)")
-    .def("__copy__", [](const Class &self) {
-      return Class(self);
-    })
-    .def("__deepcopy__", [](const Class &self, py::dict) {
-      return Class(self);
-    }, "memo"_a)
-    .def("__getitem__",
-         py::overload_cast<const std::size_t>(&Class::operator[], py::const_))
-    .def("__setitem__",
-         [](Class* vec, unsigned index, T val) { (*vec)[index] = val; })
-    .def("__str__", toString)
-    .def("__repr__", toString);
-}
-
 void defineMathVector2(py::module &m, const std::string &typestr)
 {
   helpDefineMathVector2<double>(m, typestr + "d");

--- a/src/python_pybind11/src/Vector2.cc
+++ b/src/python_pybind11/src/Vector2.cc
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+
+#include <ignition/math/Vector2.hh>
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include "Vector2.hh"
+
+using namespace pybind11::literals;
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+/// Template helper function
+template<typename T>
+void helpDefineMathVector2(py::module &m, const std::string &typestr)
+{
+  using Class = ignition::math::Vector2<T>;
+  auto toString = [](const Class &si) {
+    std::stringstream stream;
+    stream << si;
+    return stream.str();
+  };
+  std::string pyclass_name = typestr;
+  py::class_<Class>(m,
+                    pyclass_name.c_str(),
+                    py::buffer_protocol(),
+                    py::dynamic_attr())
+    .def(py::init<>())
+    .def(py::init<const T&, const T&>())
+    .def(py::init<const Class>())
+    .def("sum", &Class::Sum, "Return the sum of the values")
+    .def("distance", &Class::Distance, "Calc distance to the given point")
+    .def("length",
+         &Class::Length,
+         "Returns the length (magnitude) of the vector")
+    .def("squared_length",
+         &Class::SquaredLength,
+         "Return the square of the length (magnitude) of the vector")
+    .def("normalize", &Class::Normalize, "Normalize the vector length")
+    .def("normalized", &Class::Normalized, "Return a normalized vector")
+    .def("round",
+         &Class::Round,
+         "Round to near whole number, return the result.")
+    .def("rounded", &Class::Rounded, "Get a rounded version of this vector")
+    .def("set", &Class::Set, "Set the contents of the vector")
+    .def("dot",
+         &Class::Dot,
+         "Return the dot product of this vector and another vector")
+    .def("abs_dot", &Class::AbsDot,
+        "Return the absolute dot product of this vector and "
+        "another vector. This is similar to the Dot function, except the "
+        "absolute value of each component of the vector is used.")
+    .def("abs",
+         &Class::Abs,
+         "Get the absolute value of the vector")
+    .def("max",
+         py::overload_cast<const Class&>(&Class::Max),
+         "Set this vector's components to the maximum of itself and the "
+         "passed in vector")
+    .def("max", py::overload_cast<>(&Class::Max, py::const_),
+         "Get the maximum value in the vector")
+    .def("min", py::overload_cast<const Class&>(&Class::Min),
+         "Set this vector's components to the minimum of itself and the "
+         "passed in vector")
+    .def("min", py::overload_cast<>(&Class::Min, py::const_),
+         "Get the minimum value in the vector")
+    .def(py::self + py::self)
+    .def(py::self += py::self)
+    .def(py::self + T())
+    .def(py::self += T())
+    .def(py::self * py::self)
+    .def(py::self *= py::self)
+    .def(py::self * T())
+    .def(py::self *= T())
+    .def(py::self - py::self)
+    .def(py::self -= py::self)
+    .def(py::self - T())
+    .def(py::self -= T())
+    .def(py::self / py::self)
+    .def(py::self /= py::self)
+    .def(py::self / T())
+    .def(py::self /= T())
+    .def(py::self != py::self)
+    .def(py::self == py::self)
+    .def(-py::self)
+    .def("equal", &Class::Equal, "Equal to operator")
+    .def("is_finite",
+         &Class::IsFinite,
+         "See if a point is finite (e.g., not nan)")
+    .def("correct", &Class::Correct, "Corrects any nan values")
+    .def("x", py::overload_cast<>(&Class::X), "Get the x value.")
+    .def("y", py::overload_cast<>(&Class::Y), "Get the y value.")
+    .def("x", py::overload_cast<const T&>(&Class::X), "Set the x value.")
+    .def("y", py::overload_cast<const T&>(&Class::Y), "Set the y value.")
+    .def_readonly_static("ZERO", &Class::Zero, "math::Vector2(0, 0)")
+    .def_readonly_static("ONE", &Class::One, "math::Vector2(1, 1)")
+    .def_readonly_static("NAN", &Class::NaN, "math::Vector3(NaN, NaN)")
+    .def("__copy__", [](const Class &self) {
+      return Class(self);
+    })
+    .def("__deepcopy__", [](const Class &self, py::dict) {
+      return Class(self);
+    }, "memo"_a)
+    .def("__getitem__",
+         py::overload_cast<const std::size_t>(&Class::operator[], py::const_))
+    .def("__setitem__",
+         [](Class* vec, unsigned index, T val) { (*vec)[index] = val; })
+    .def("__str__", toString)
+    .def("__repr__", toString);
+}
+
+void defineMathVector2(py::module &m, const std::string &typestr)
+{
+  helpDefineMathVector2<double>(m, typestr + "d");
+  helpDefineMathVector2<float>(m, typestr + "f");
+  helpDefineMathVector2<int>(m, typestr + "i");
+}
+
+}  // namespace python
+}  // namespace gazebo
+}  // namespace ignition

--- a/src/python_pybind11/src/Vector2.hh
+++ b/src/python_pybind11/src/Vector2.hh
@@ -15,18 +15,14 @@
  *
 */
 
-#ifndef IGNITION_MATH_PYTHON__VECTOR2D_HH_
-#define IGNITION_MATH_PYTHON__VECTOR2D_HH_
+#ifndef IGNITION_MATH_PYTHON__VECTOR2_HH_
+#define IGNITION_MATH_PYTHON__VECTOR2_HH_
 
 #include <string>
 
 #include <pybind11/pybind11.h>
-#include <pybind11/operators.h>
-
-#include <ignition/math/Vector2.hh>
 
 namespace py = pybind11;
-using namespace pybind11::literals;
 
 namespace ignition
 {
@@ -38,106 +34,9 @@ namespace python
 /**
  * \param[in] module a pybind11 module to add the definition to
  */
-template<typename T>
-void defineMathVector2(py::module &m, const std::string &typestr)
-{
-  using Class = ignition::math::Vector2<T>;
-  auto toString = [](const Class &si) {
-    std::stringstream stream;
-    stream << si;
-    return stream.str();
-  };
-  std::string pyclass_name = typestr;
-  py::class_<Class>(m,
-                    pyclass_name.c_str(),
-                    py::buffer_protocol(),
-                    py::dynamic_attr())
-    .def(py::init<>())
-    .def(py::init<const T&, const T&>())
-    .def(py::init<const Class>())
-    .def("sum", &Class::Sum, "Return the sum of the values")
-    .def("distance", &Class::Distance, "Calc distance to the given point")
-    .def("length",
-         &Class::Length,
-         "Returns the length (magnitude) of the vector")
-    .def("squared_length",
-         &Class::SquaredLength,
-         "Return the square of the length (magnitude) of the vector")
-    .def("normalize", &Class::Normalize, "Normalize the vector length")
-    .def("normalized", &Class::Normalized, "Return a normalized vector")
-    .def("round",
-         &Class::Round,
-         "Round to near whole number, return the result.")
-    .def("rounded", &Class::Rounded, "Get a rounded version of this vector")
-    .def("set", &Class::Set, "Set the contents of the vector")
-    .def("dot",
-         &Class::Dot,
-         "Return the dot product of this vector and another vector")
-    .def("abs_dot", &Class::AbsDot,
-        "Return the absolute dot product of this vector and "
-        "another vector. This is similar to the Dot function, except the "
-        "absolute value of each component of the vector is used.")
-    .def("abs",
-         &Class::Abs,
-         "Get the absolute value of the vector")
-    .def("max",
-         py::overload_cast<const Class&>(&Class::Max),
-         "Set this vector's components to the maximum of itself and the "
-         "passed in vector")
-    .def("max", py::overload_cast<>(&Class::Max, py::const_),
-         "Get the maximum value in the vector")
-    .def("min", py::overload_cast<const Class&>(&Class::Min),
-         "Set this vector's components to the minimum of itself and the "
-         "passed in vector")
-    .def("min", py::overload_cast<>(&Class::Min, py::const_),
-         "Get the minimum value in the vector")
-    .def(py::self + py::self)
-    .def(py::self += py::self)
-    .def(py::self + T())
-    .def(py::self += T())
-    .def(py::self * py::self)
-    .def(py::self *= py::self)
-    .def(py::self * T())
-    .def(py::self *= T())
-    .def(py::self - py::self)
-    .def(py::self -= py::self)
-    .def(py::self - T())
-    .def(py::self -= T())
-    .def(py::self / py::self)
-    .def(py::self /= py::self)
-    .def(py::self / T())
-    .def(py::self /= T())
-    .def(py::self != py::self)
-    .def(py::self == py::self)
-    .def(-py::self)
-    .def("equal", &Class::Equal, "Equal to operator")
-    .def("is_finite",
-         &Class::IsFinite,
-         "See if a point is finite (e.g., not nan)")
-    .def("correct", &Class::Correct, "Corrects any nan values")
-    .def("x", py::overload_cast<>(&Class::X), "Get the x value.")
-    .def("y", py::overload_cast<>(&Class::Y), "Get the y value.")
-    .def("x", py::overload_cast<const T&>(&Class::X), "Set the x value.")
-    .def("y", py::overload_cast<const T&>(&Class::Y), "Set the y value.")
-    .def_readonly_static("ZERO", &Class::Zero, "math::Vector2(0, 0)")
-    .def_readonly_static("ONE", &Class::One, "math::Vector2(1, 1)")
-    .def_readonly_static("NAN", &Class::NaN, "math::Vector3(NaN, NaN)")
-    .def("__copy__", [](const Class &self) {
-      return Class(self);
-    })
-    .def("__deepcopy__", [](const Class &self, py::dict) {
-      return Class(self);
-    }, "memo"_a)
-    .def("__getitem__",
-         py::overload_cast<const std::size_t>(&Class::operator[], py::const_))
-    .def("__setitem__",
-         [](Class* vec, unsigned index, T val) { (*vec)[index] = val; })
-    .def("__str__", toString)
-    .def("__repr__", toString);
-}
-
+void defineMathVector2(py::module &m, const std::string &typestr);
 }  // namespace python
 }  // namespace gazebo
 }  // namespace ignition
 
-#endif  // IGNITION_MATH_PYTHON__VECTOR2D_HH_
+#endif  // IGNITION_MATH_PYTHON__VECTOR2_HH_

--- a/src/python_pybind11/src/Vector2.hh
+++ b/src/python_pybind11/src/Vector2.hh
@@ -21,8 +21,12 @@
 #include <string>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include <ignition/math/Vector2.hh>
 
 namespace py = pybind11;
+using namespace pybind11::literals;
 
 namespace ignition
 {
@@ -30,6 +34,108 @@ namespace math
 {
 namespace python
 {
+/// Help define a pybind11 wrapper for an ignition::math::Vector2
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ */
+template<typename T>
+void helpDefineMathVector2(py::module &m, const std::string &typestr)
+{
+  using Class = ignition::math::Vector2<T>;
+  auto toString = [](const Class &si) {
+    std::stringstream stream;
+    stream << si;
+    return stream.str();
+  };
+  std::string pyclass_name = typestr;
+  py::class_<Class>(m,
+                    pyclass_name.c_str(),
+                    py::buffer_protocol(),
+                    py::dynamic_attr())
+    .def(py::init<>())
+    .def(py::init<const T&, const T&>())
+    .def(py::init<const Class>())
+    .def("sum", &Class::Sum, "Return the sum of the values")
+    .def("distance", &Class::Distance, "Calc distance to the given point")
+    .def("length",
+         &Class::Length,
+         "Returns the length (magnitude) of the vector")
+    .def("squared_length",
+         &Class::SquaredLength,
+         "Return the square of the length (magnitude) of the vector")
+    .def("normalize", &Class::Normalize, "Normalize the vector length")
+    .def("normalized", &Class::Normalized, "Return a normalized vector")
+    .def("round",
+         &Class::Round,
+         "Round to near whole number, return the result.")
+    .def("rounded", &Class::Rounded, "Get a rounded version of this vector")
+    .def("set", &Class::Set, "Set the contents of the vector")
+    .def("dot",
+         &Class::Dot,
+         "Return the dot product of this vector and another vector")
+    .def("abs_dot", &Class::AbsDot,
+        "Return the absolute dot product of this vector and "
+        "another vector. This is similar to the Dot function, except the "
+        "absolute value of each component of the vector is used.")
+    .def("abs",
+         &Class::Abs,
+         "Get the absolute value of the vector")
+    .def("max",
+         py::overload_cast<const Class&>(&Class::Max),
+         "Set this vector's components to the maximum of itself and the "
+         "passed in vector")
+    .def("max", py::overload_cast<>(&Class::Max, py::const_),
+         "Get the maximum value in the vector")
+    .def("min", py::overload_cast<const Class&>(&Class::Min),
+         "Set this vector's components to the minimum of itself and the "
+         "passed in vector")
+    .def("min", py::overload_cast<>(&Class::Min, py::const_),
+         "Get the minimum value in the vector")
+    .def(py::self + py::self)
+    .def(py::self += py::self)
+    .def(py::self + T())
+    .def(py::self += T())
+    .def(py::self * py::self)
+    .def(py::self *= py::self)
+    .def(py::self * T())
+    .def(py::self *= T())
+    .def(py::self - py::self)
+    .def(py::self -= py::self)
+    .def(py::self - T())
+    .def(py::self -= T())
+    .def(py::self / py::self)
+    .def(py::self /= py::self)
+    .def(py::self / T())
+    .def(py::self /= T())
+    .def(py::self != py::self)
+    .def(py::self == py::self)
+    .def(-py::self)
+    .def("equal", &Class::Equal, "Equal to operator")
+    .def("is_finite",
+         &Class::IsFinite,
+         "See if a point is finite (e.g., not nan)")
+    .def("correct", &Class::Correct, "Corrects any nan values")
+    .def("x", py::overload_cast<>(&Class::X), "Get the x value.")
+    .def("y", py::overload_cast<>(&Class::Y), "Get the y value.")
+    .def("x", py::overload_cast<const T&>(&Class::X), "Set the x value.")
+    .def("y", py::overload_cast<const T&>(&Class::Y), "Set the y value.")
+    .def_readonly_static("ZERO", &Class::Zero, "math::Vector2(0, 0)")
+    .def_readonly_static("ONE", &Class::One, "math::Vector2(1, 1)")
+    .def_readonly_static("NAN", &Class::NaN, "math::Vector3(NaN, NaN)")
+    .def("__copy__", [](const Class &self) {
+      return Class(self);
+    })
+    .def("__deepcopy__", [](const Class &self, py::dict) {
+      return Class(self);
+    }, "memo"_a)
+    .def("__getitem__",
+         py::overload_cast<const std::size_t>(&Class::operator[], py::const_))
+    .def("__setitem__",
+         [](Class* vec, unsigned index, T val) { (*vec)[index] = val; })
+    .def("__str__", toString)
+    .def("__repr__", toString);
+}
+
 /// Define a pybind11 wrapper for an ignition::math::Vector2
 /**
  * \param[in] module a pybind11 module to add the definition to

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -118,9 +118,7 @@ PYBIND11_MODULE(math, m)
 
   ignition::math::python::defineMathTemperature(m, "Temperature");
 
-  ignition::math::python::defineMathVector2<double>(m, "Vector2d");
-  ignition::math::python::defineMathVector2<int>(m, "Vector2i");
-  ignition::math::python::defineMathVector2<float>(m, "Vector2f");
+  ignition::math::python::defineMathVector2(m, "Vector2");
 
   ignition::math::python::defineMathVector3<double>(m, "Vector3d");
   ignition::math::python::defineMathVector3<int>(m, "Vector3i");


### PR DESCRIPTION
# 🦟 Bug fix

We observed some instances of ign-math6 CI jobs failing due to running out of memory during compilation of the pybind11 interfaces. This is a prototype for how to reduce memory usage.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-math6-debbuilder&build=1334)](https://build.osrfoundation.org/job/ign-math6-debbuilder/1334/) https://build.osrfoundation.org/job/ign-math6-debbuilder/1334/

## Summary

Currently all pybind11 template interfaces are compiled in the same translation unit in [_ignition_math_pybind11.cc](https://github.com/ignitionrobotics/ign-math/blob/ign-math6/src/python_pybind11/src/_ignition_math_pybind11.cc#L121-L196). It is hypothesized that this contributes to the substantial memory consumption. This pull request provides a prototype of how to reduce that memory consumption by moving the template instantiations from `_ignition_math_pybind11.cc` to a separate translation unit `Vector2.cc`. Thanks to @sloretz for suggesting the approach.

I also made a minor change in https://github.com/ignitionrobotics/ign-math/commit/62b65e05edb1ec824a7bf645881d546ef2da6f78 that reduces the number of header files indirectly included by `_ignition_math_pybind11.cc`. This may not be impactful but is easy to do.

We can repeat this approach for the remaining files in a follow-up pull request if it is approved.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
