### PR TITLE
[math7] Tidy up unused variables

### DIFF
--- a/include/ignition/math/Quaternion.hh
+++ b/include/ignition/math/Quaternion.hh
@@ -303,7 +303,7 @@ namespace ignition
       /// \deprecated Use SetFromAxisAngle(T, T, T, T)
       public: void IGN_DEPRECATED(7) Axis(T _ax, T _ay, T _az, T _aa)
       {
-        this->SetFromAxisAngle(_ax, _ay, _ax, _aa);
+        this->SetFromAxisAngle(_ax, _ay, _az, _aa);
       }
 
       /// \brief Set the quaternion from an axis and angle.
@@ -716,7 +716,6 @@ namespace ignition
       /// \param[in] _scale Amount to scale this quaternion
       public: void Scale(T _scale)
       {
-        Quaternion<T> b;
         Vector3<T> axis;
         T angle;
 

--- a/src/PID_TEST.cc
+++ b/src/PID_TEST.cc
@@ -108,40 +108,6 @@ TEST(PidTest, SetValues)
 }
 
 /////////////////////////////////////////////////
-TEST(PidTest, EqualOperatorCornerCase)
-{
-  math::PID pid(1.0, 2.1, -4.5, 10.5, 1.4, 45, -35, 1.23);
-  EXPECT_DOUBLE_EQ(pid.PGain(), 1.0);
-  EXPECT_DOUBLE_EQ(pid.IGain(), 2.1);
-  EXPECT_DOUBLE_EQ(pid.DGain(), -4.5);
-  EXPECT_DOUBLE_EQ(pid.IMax(), 10.5);
-  EXPECT_DOUBLE_EQ(pid.IMin(), 1.4);
-  EXPECT_DOUBLE_EQ(pid.CmdMax(), 45.0);
-  EXPECT_DOUBLE_EQ(pid.CmdMin(), -35.0);
-  EXPECT_DOUBLE_EQ(pid.CmdOffset(), 1.23);
-  EXPECT_DOUBLE_EQ(pid.Cmd(), 0.0);
-
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wself-assign-overloaded"
-#endif
-  pid = pid;
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-
-  EXPECT_DOUBLE_EQ(pid.PGain(), 1.0);
-  EXPECT_DOUBLE_EQ(pid.IGain(), 2.1);
-  EXPECT_DOUBLE_EQ(pid.DGain(), -4.5);
-  EXPECT_DOUBLE_EQ(pid.IMax(), 10.5);
-  EXPECT_DOUBLE_EQ(pid.IMin(), 1.4);
-  EXPECT_DOUBLE_EQ(pid.CmdMax(), 45.0);
-  EXPECT_DOUBLE_EQ(pid.CmdMin(), -35.0);
-  EXPECT_DOUBLE_EQ(pid.CmdOffset(), 1.23);
-  EXPECT_DOUBLE_EQ(pid.Cmd(), 0.0);
-}
-
-/////////////////////////////////////////////////
 TEST(PidTest, Update)
 {
   math::PID pid;

--- a/src/PID_TEST.cc
+++ b/src/PID_TEST.cc
@@ -121,7 +121,14 @@ TEST(PidTest, EqualOperatorCornerCase)
   EXPECT_DOUBLE_EQ(pid.CmdOffset(), 1.23);
   EXPECT_DOUBLE_EQ(pid.Cmd(), 0.0);
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
   pid = pid;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
   EXPECT_DOUBLE_EQ(pid.PGain(), 1.0);
   EXPECT_DOUBLE_EQ(pid.IGain(), 2.1);
@@ -336,14 +343,14 @@ TEST(PidTest, Pcontrol)
   for (int i = 0; i < N; ++i)
   {
     double d = static_cast<double>(i);
-    EXPECT_DOUBLE_EQ(-d, pid.Update(d, std::chrono::duration<double>(1)));
+    EXPECT_DOUBLE_EQ(-d, pid.Update(d, dt));
   }
 
   pid.SetPGain(2);
   for (int i = 0; i < N; ++i)
   {
     double d = static_cast<double>(i);
-    EXPECT_DOUBLE_EQ(-2*d, pid.Update(d, std::chrono::duration<double>(1)));
+    EXPECT_DOUBLE_EQ(-2*d, pid.Update(d, dt));
   }
 }
 
@@ -356,7 +363,7 @@ TEST(PidTest, Icontrol)
   for (int i = 0; i < N; ++i)
   {
     double d = static_cast<double>(i+1);
-    EXPECT_DOUBLE_EQ(-d, pid.Update(1, std::chrono::duration<double>(1)));
+    EXPECT_DOUBLE_EQ(-d, pid.Update(1, dt));
   }
 
   pid.SetIGain(2);
@@ -369,13 +376,13 @@ TEST(PidTest, Icontrol)
   }
 
   // confirm that changing gain doesn't cause jumps in integral control
-  EXPECT_DOUBLE_EQ(-I0, pid.Update(0, std::chrono::duration<double>(1)));
-  EXPECT_DOUBLE_EQ(-I0, pid.Update(0, std::chrono::duration<double>(1)));
+  EXPECT_DOUBLE_EQ(-I0, pid.Update(0, dt));
+  EXPECT_DOUBLE_EQ(-I0, pid.Update(0, dt));
 
   for (int i = 0; i < N; ++i)
   {
     double d = static_cast<double>(i+1);
-    EXPECT_DOUBLE_EQ(-I0-2*d, pid.Update(1, std::chrono::duration<double>(1)));
+    EXPECT_DOUBLE_EQ(-I0-2*d, pid.Update(1, dt));
   }
 }
 
@@ -384,19 +391,19 @@ TEST(PidTest, Dcontrol)
 {
   math::PID pid(0, 0, 1);
   std::chrono::duration<double> dt(1);
-  EXPECT_DOUBLE_EQ(1, pid.Update(-1, std::chrono::duration<double>(1)));
+  EXPECT_DOUBLE_EQ(1, pid.Update(-1, dt));
   const int N = 5;
   for (int i = 0; i < N; ++i)
   {
     double d = static_cast<double>(i);
-    EXPECT_DOUBLE_EQ(-1, pid.Update(d, std::chrono::duration<double>(1)));
+    EXPECT_DOUBLE_EQ(-1, pid.Update(d, dt));
   }
 
   pid.SetDGain(2);
-  EXPECT_DOUBLE_EQ(10, pid.Update(-1, std::chrono::duration<double>(1)));
+  EXPECT_DOUBLE_EQ(10, pid.Update(-1, dt));
   for (int i = 0; i < N; ++i)
   {
     double d = static_cast<double>(i);
-    EXPECT_DOUBLE_EQ(-2, pid.Update(d, std::chrono::duration<double>(1)));
+    EXPECT_DOUBLE_EQ(-2, pid.Update(d, dt));
   }
 }

--- a/src/Quaternion_TEST.cc
+++ b/src/Quaternion_TEST.cc
@@ -324,6 +324,21 @@ TEST(QuaternionTest, MathAxis)
 {
   math::Quaterniond q(IGN_PI*0.1, IGN_PI*0.5, IGN_PI);
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  // Deprecated in ign-math7
+  q.Axis(0, 1, 0, IGN_PI);
+  EXPECT_EQ(q, math::Quaterniond(6.12303e-17, 0, 1, 0));
+
+  // Deprecated in ign-math7
+  q.Axis(1, 0, 0, IGN_PI);
+  EXPECT_EQ(q, math::Quaterniond(0, 1, 0, 0));
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
   q.SetFromAxisAngle(0, 1, 0, IGN_PI);
   EXPECT_EQ(q, math::Quaterniond(6.12303e-17, 0, 1, 0));
 

--- a/src/Quaternion_TEST.cc
+++ b/src/Quaternion_TEST.cc
@@ -23,6 +23,7 @@
 #include "ignition/math/Quaternion.hh"
 #include "ignition/math/Matrix3.hh"
 #include "ignition/math/Matrix4.hh"
+#include <ignition/utils/SuppressWarning.hh>
 
 using namespace ignition;
 
@@ -324,10 +325,7 @@ TEST(QuaternionTest, MathAxis)
 {
   math::Quaterniond q(IGN_PI*0.1, IGN_PI*0.5, IGN_PI);
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
+IGN_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   // Deprecated in ign-math7
   q.Axis(0, 1, 0, IGN_PI);
   EXPECT_EQ(q, math::Quaterniond(6.12303e-17, 0, 1, 0));
@@ -335,9 +333,7 @@ TEST(QuaternionTest, MathAxis)
   // Deprecated in ign-math7
   q.Axis(1, 0, 0, IGN_PI);
   EXPECT_EQ(q, math::Quaterniond(0, 1, 0, 0));
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
+IGN_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 
   q.SetFromAxisAngle(0, 1, 0, IGN_PI);
   EXPECT_EQ(q, math::Quaterniond(6.12303e-17, 0, 1, 0));

--- a/src/SphericalCoordinates_TEST.cc
+++ b/src/SphericalCoordinates_TEST.cc
@@ -208,8 +208,6 @@ TEST(SphericalCoordinatesTest, CoordinateTransforms)
       ignition::math::Vector3d osrf_e(
           -2693701.91434394, -4299942.14687992, 3851691.0393571);
       ignition::math::Vector3d goog_s(37.4216719, -122.0821853, 30.0);
-      ignition::math::Vector3d goog_e(
-          -2693766.71906146, -4297199.59926038, 3854681.81878812);
 
       // Local tangent plane coordinates (ENU = GLOBAL) coordinates of
       // Google when OSRF is taken as the origin:


### PR DESCRIPTION
Uncovered a few things during a clang-12 build.

The big one is that we weren't correctly forwarding arguments in `Quaternion::Axis`, so I fixed it and added a test to prevent further regressions.

Everything else was unused variables.