### PR TITLE
More pybind11 compilation memory savings

### DIFF
--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -13,6 +13,7 @@ pybind11_add_module(math SHARED
   src/AxisAlignedBox.cc
   src/Color.cc
   src/DiffDriveOdometry.cc
+  src/Filter.cc
   src/Frustum.cc
   src/GaussMarkovProcess.cc
   src/Helpers.cc

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -18,6 +18,7 @@ pybind11_add_module(math SHARED
   src/Helpers.cc
   src/Kmeans.cc
   src/Material.cc
+  src/MovingWindowFilter.cc
   src/PID.cc
   src/Rand.cc
   src/RollingMean.cc

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -19,6 +19,7 @@ pybind11_add_module(math SHARED
   src/Helpers.cc
   src/Kmeans.cc
   src/Line2.cc
+  src/Line3.cc
   src/Material.cc
   src/MovingWindowFilter.cc
   src/PID.cc

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -18,6 +18,7 @@ pybind11_add_module(math SHARED
   src/GaussMarkovProcess.cc
   src/Helpers.cc
   src/Kmeans.cc
+  src/Line2.cc
   src/Material.cc
   src/MovingWindowFilter.cc
   src/PID.cc

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -29,6 +29,8 @@ pybind11_add_module(math SHARED
   src/StopWatch.cc
   src/Temperature.cc
   src/Vector2.cc
+  src/Vector3.cc
+  src/Vector4.cc
   src/Vector3Stats.cc
 )
 

--- a/src/python_pybind11/src/Filter.cc
+++ b/src/python_pybind11/src/Filter.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "Filter.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathFilter(py::module &m, const std::string &typestr)
+{
+  helpDefineMathFilter<int>(m, typestr + "i");
+  helpDefineMathFilter<float>(m, typestr + "f");
+  helpDefineMathFilter<double>(m, typestr + "d");
+}
+
+void defineMathOnePole(py::module &m, const std::string &typestr)
+{
+  helpDefineMathOnePole<int>(m, typestr + "i");
+  helpDefineMathOnePole<float>(m, typestr + "f");
+  helpDefineMathOnePole<double>(m, typestr + "d");
+}
+
+void defineMathOnePoleQuaternion(py::module &m, const std::string &typestr)
+{
+  using Class = ignition::math::OnePoleQuaternion;
+  std::string pyclass_name = typestr;
+  py::class_<Class>(m,
+                    pyclass_name.c_str(),
+                    py::buffer_protocol(),
+                    py::dynamic_attr())
+    .def(py::init<>())
+    .def(py::init<double, double>())
+    .def("set",
+         &Class::Set,
+         "Set the output of the filter.")
+    .def("value",
+         &Class::Value,
+         "Get the output of the filter.")
+    .def("fc",
+         &Class::Fc,
+         "Set the cutoff frequency and sample rate.")
+    .def("process",
+         &Class::Process,
+         "Update the filter's output.");
+}
+
+void defineMathOnePoleVector3(py::module &m, const std::string &typestr)
+{
+  using Class = ignition::math::OnePoleVector3;
+  std::string pyclass_name = typestr;
+  py::class_<Class>(m,
+                    pyclass_name.c_str(),
+                    py::buffer_protocol(),
+                    py::dynamic_attr())
+    .def(py::init<>())
+    .def(py::init<double, double>())
+    .def("set",
+         &Class::Set,
+         "Set the output of the filter.")
+    .def("value",
+         &Class::
+         Value,
+         "Get the output of the filter.")
+    .def("fc",
+         &Class::Fc,
+         "Set the cutoff frequency and sample rate.")
+    .def("process",
+         &Class::Process,
+         "Update the filter's output.");
+}
+
+void defineMathBiQuad(py::module &m, const std::string &typestr)
+{
+  helpDefineMathBiQuad<int>(m, typestr + "i");
+  helpDefineMathBiQuad<float>(m, typestr + "f");
+  helpDefineMathBiQuad<double>(m, typestr + "d");
+}
+
+void defineMathBiQuadVector3(py::module &m, const std::string &typestr)
+{
+  using Class = ignition::math::BiQuadVector3;
+  std::string pyclass_name = typestr;
+  py::class_<Class>(m,
+                    pyclass_name.c_str(),
+                    py::buffer_protocol(),
+                    py::dynamic_attr())
+    .def(py::init<>())
+    .def(py::init<double, double>())
+    .def("set",
+         &Class::Set,
+         "Set the output of the filter.")
+    .def("fc",
+          py::overload_cast<double, double>(&Class::Fc),
+         "Set the cutoff frequency and sample rate.")
+    .def("value",
+         &Class::Value,
+         "Get the output of the filter.")
+    .def("fc",
+         py::overload_cast<double, double, double>(&Class::Fc),
+         "Set the cutoff frequency, sample rate and Q coefficient.")
+    .def("process",
+         &Class::Process,
+         "Update the filter's output.");
+}
+}  // namespace python
+}  // namespace math
+}  // namespace ignition

--- a/src/python_pybind11/src/Filter.hh
+++ b/src/python_pybind11/src/Filter.hh
@@ -71,13 +71,13 @@ public:
     }
 };
 
-/// Define a pybind11 wrapper for an ignition::math::Filter
+/// Help define a pybind11 wrapper for an ignition::math::Filter
 /**
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
 template<typename T>
-void defineMathFilter(py::module &m, const std::string &typestr)
+void helpDefineMathFilter(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::Filter<T>;
   std::string pyclass_name = typestr;
@@ -96,6 +96,13 @@ void defineMathFilter(py::module &m, const std::string &typestr)
          &Class::Value,
          "Get the output of the filter.");
 }
+
+/// Define a pybind11 wrapper for an ignition::math::Filter
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
+void defineMathFilter(py::module &m, const std::string &typestr);
 
 template<typename T>
 class OnePoleTrampoline : public OnePole<T> {
@@ -116,13 +123,13 @@ public:
   }
 };
 
-/// Define a pybind11 wrapper for an ignition::math::OnePole
+/// Help define a pybind11 wrapper for an ignition::math::OnePole
 /**
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
 template<typename T>
-void defineMathOnePole(py::module &m, const std::string &typestr)
+void helpDefineMathOnePole(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::OnePole<T>;
   std::string pyclass_name = typestr;
@@ -146,64 +153,26 @@ void defineMathOnePole(py::module &m, const std::string &typestr)
          "Update the filter's output.");
 }
 
+/// Define a pybind11 wrapper for an ignition::math::OnePole
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
+void defineMathOnePole(py::module &m, const std::string &typestr);
+
 /// Define a pybind11 wrapper for an ignition::math::OnePoleQuaterion
 /**
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
-void defineMathOnePoleQuaternion(py::module &m, const std::string &typestr)
-{
-  using Class = ignition::math::OnePoleQuaternion;
-  std::string pyclass_name = typestr;
-  py::class_<Class>(m,
-                    pyclass_name.c_str(),
-                    py::buffer_protocol(),
-                    py::dynamic_attr())
-    .def(py::init<>())
-    .def(py::init<double, double>())
-    .def("set",
-         &Class::Set,
-         "Set the output of the filter.")
-    .def("value",
-         &Class::Value,
-         "Get the output of the filter.")
-    .def("fc",
-         &Class::Fc,
-         "Set the cutoff frequency and sample rate.")
-    .def("process",
-         &Class::Process,
-         "Update the filter's output.");
-}
+void defineMathOnePoleQuaternion(py::module &m, const std::string &typestr);
 
 /// Define a pybind11 wrapper for an ignition::math::OnePoleVector3
 /**
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
-void defineMathOnePoleVector3(py::module &m, const std::string &typestr)
-{
-  using Class = ignition::math::OnePoleVector3;
-  std::string pyclass_name = typestr;
-  py::class_<Class>(m,
-                    pyclass_name.c_str(),
-                    py::buffer_protocol(),
-                    py::dynamic_attr())
-    .def(py::init<>())
-    .def(py::init<double, double>())
-    .def("set",
-         &Class::Set,
-         "Set the output of the filter.")
-    .def("value",
-         &Class::
-         Value,
-         "Get the output of the filter.")
-    .def("fc",
-         &Class::Fc,
-         "Set the cutoff frequency and sample rate.")
-    .def("process",
-         &Class::Process,
-         "Update the filter's output.");
-}
+void defineMathOnePoleVector3(py::module &m, const std::string &typestr);
 
 template<typename T>
 class BiQuadTrampoline : public BiQuad<T>
@@ -244,13 +213,13 @@ public:
   }
 };
 
-/// Define a pybind11 wrapper for an ignition::math::BiQuad
+/// Help define a pybind11 wrapper for an ignition::math::BiQuad
 /**
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
 template<typename T>
-void defineMathBiQuad(py::module &m, const std::string &typestr)
+void helpDefineMathBiQuad(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::BiQuad<T>;
   std::string pyclass_name = typestr;
@@ -277,37 +246,20 @@ void defineMathBiQuad(py::module &m, const std::string &typestr)
          "Update the filter's output.");
 }
 
+/// Define a pybind11 wrapper for an ignition::math::BiQuad
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
+void defineMathBiQuad(py::module &m, const std::string &typestr);
+
 /// Define a pybind11 wrapper for an ignition::math::BiQuadVector3
 /**
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
-void defineMathBiQuadVector3(py::module &m, const std::string &typestr)
-{
-  using Class = ignition::math::BiQuadVector3;
-  std::string pyclass_name = typestr;
-  py::class_<Class>(m,
-                    pyclass_name.c_str(),
-                    py::buffer_protocol(),
-                    py::dynamic_attr())
-    .def(py::init<>())
-    .def(py::init<double, double>())
-    .def("set",
-         &Class::Set,
-         "Set the output of the filter.")
-    .def("fc",
-          py::overload_cast<double, double>(&Class::Fc),
-         "Set the cutoff frequency and sample rate.")
-    .def("value",
-         &Class::Value,
-         "Get the output of the filter.")
-    .def("fc",
-         py::overload_cast<double, double, double>(&Class::Fc),
-         "Set the cutoff frequency, sample rate and Q coefficient.")
-    .def("process",
-         &Class::Process,
-         "Update the filter's output.");
-}
+void defineMathBiQuadVector3(py::module &m, const std::string &typestr);
+
 }  // namespace python
 }  // namespace math
 }  // namespace ignition

--- a/src/python_pybind11/src/Line2.cc
+++ b/src/python_pybind11/src/Line2.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "Line2.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathLine2(py::module &m, const std::string &typestr)
+{
+  helpDefineMathLine2<int>(m, typestr + "i");
+  helpDefineMathLine2<float>(m, typestr + "f");
+  helpDefineMathLine2<double>(m, typestr + "d");
+}
+
+}  // namespace python
+}  // namespace math
+}  // namespace ignition

--- a/src/python_pybind11/src/Line2.hh
+++ b/src/python_pybind11/src/Line2.hh
@@ -34,13 +34,13 @@ namespace math
 {
 namespace python
 {
-/// Define a pybind11 wrapper for an ignition::math::Line2
+/// Help define a pybind11 wrapper for an ignition::math::Line2
 /**
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
 template<typename T>
-void defineMathLine2(py::module &m, const std::string &typestr)
+void helpDefineMathLine2(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::Line2<T>;
   auto toString = [](const Class &si) {
@@ -127,6 +127,13 @@ void defineMathLine2(py::module &m, const std::string &typestr)
     .def("__str__", toString)
     .def("__repr__", toString);
 }
+
+/// Define a pybind11 wrapper for an ignition::math::Line2
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
+void defineMathLine2(py::module &m, const std::string &typestr);
 
 }  // namespace python
 }  // namespace math

--- a/src/python_pybind11/src/Line3.cc
+++ b/src/python_pybind11/src/Line3.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "Line3.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathLine3(py::module &m, const std::string &typestr)
+{
+  helpDefineMathLine3<int>(m, typestr + "i");
+  helpDefineMathLine3<float>(m, typestr + "f");
+  helpDefineMathLine3<double>(m, typestr + "d");
+}
+
+}  // namespace python
+}  // namespace math
+}  // namespace ignition

--- a/src/python_pybind11/src/Line3.hh
+++ b/src/python_pybind11/src/Line3.hh
@@ -35,13 +35,13 @@ namespace math
 {
 namespace python
 {
-/// Define a pybind11 wrapper for an ignition::math::Line3
+/// Help define a pybind11 wrapper for an ignition::math::Line3
 /**
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
 template<typename T>
-void defineMathLine3(py::module &m, const std::string &typestr)
+void helpDefineMathLine3(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::Line3<T>;
   auto toString = [](const Class &si) {
@@ -144,6 +144,13 @@ void defineMathLine3(py::module &m, const std::string &typestr)
     .def("__str__", toString)
     .def("__repr__", toString);
 }
+
+/// Define a pybind11 wrapper for an ignition::math::Line3
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
+void defineMathLine3(py::module &m, const std::string &typestr);
 }  // namespace python
 }  // namespace math
 }  // namespace ignition

--- a/src/python_pybind11/src/MovingWindowFilter.cc
+++ b/src/python_pybind11/src/MovingWindowFilter.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+
+#include <ignition/math/Vector3.hh>
+#include "MovingWindowFilter.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathMovingWindowFilter(py::module &m, const std::string &typestr)
+{
+  helpDefineMathMovingWindowFilter<int>(m, typestr + "i");
+  helpDefineMathMovingWindowFilter<double>(m, typestr + "d");
+  helpDefineMathMovingWindowFilter<ignition::math::Vector3d>(m, typestr + "v3");
+}
+
+}  // namespace python
+}  // namespace gazebo
+}  // namespace ignition

--- a/src/python_pybind11/src/MovingWindowFilter.hh
+++ b/src/python_pybind11/src/MovingWindowFilter.hh
@@ -33,13 +33,13 @@ namespace math
 {
 namespace python
 {
-/// Define a pybind11 wrapper for an ignition::math::MovingWindowFilter
+/// Help define a pybind11 wrapper for an ignition::math::MovingWindowFilter
 /**
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
 template<typename T>
-void defineMathMovingWindowFilter(py::module &m, const std::string &typestr)
+void helpDefineMathMovingWindowFilter(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::MovingWindowFilter<T>;
   std::string pyclass_name = typestr;
@@ -57,6 +57,12 @@ void defineMathMovingWindowFilter(py::module &m, const std::string &typestr)
     .def("value", &Class::Value, "Get filtered result");
 }
 
+/// Define a pybind11 wrapper for an ignition::math::MovingWindowFilter
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
+void defineMathMovingWindowFilter(py::module &m, const std::string &typestr);
 }  // namespace python
 }  // namespace math
 }  // namespace ignition

--- a/src/python_pybind11/src/Vector3.cc
+++ b/src/python_pybind11/src/Vector3.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+
+#include "Vector3.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathVector3(py::module &m, const std::string &typestr)
+{
+  helpDefineMathVector3<double>(m, typestr + "d");
+  helpDefineMathVector3<float>(m, typestr + "f");
+  helpDefineMathVector3<int>(m, typestr + "i");
+}
+
+}  // namespace python
+}  // namespace gazebo
+}  // namespace ignition

--- a/src/python_pybind11/src/Vector3.hh
+++ b/src/python_pybind11/src/Vector3.hh
@@ -15,8 +15,8 @@
  *
 */
 
-#ifndef IGNITION_MATH_PYTHON__VECTOR3D_HH_
-#define IGNITION_MATH_PYTHON__VECTOR3D_HH_
+#ifndef IGNITION_MATH_PYTHON__VECTOR3_HH_
+#define IGNITION_MATH_PYTHON__VECTOR3_HH_
 
 #include <string>
 
@@ -34,12 +34,12 @@ namespace math
 {
 namespace python
 {
-/// Define a pybind11 wrapper for an ignition::math::Vector3
+/// Help define a pybind11 wrapper for an ignition::math::Vector3
 /**
  * \param[in] module a pybind11 module to add the definition to
  */
 template<typename T>
-void defineMathVector3(py::module &m, const std::string &typestr)
+void helpDefineMathVector3(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::Vector3<T>;
   auto toString = [](const Class &si) {
@@ -159,8 +159,14 @@ void defineMathVector3(py::module &m, const std::string &typestr)
     .def("__str__", toString)
     .def("__repr__", toString);
 }
+
+/// Define a pybind11 wrapper for an ignition::math::Vector2
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ */
+void defineMathVector3(py::module &m, const std::string &typestr);
 }  // namespace python
 }  // namespace gazebo
 }  // namespace ignition
 
-#endif  // IGNITION_MATH_PYTHON__VECTOR3D_HH_
+#endif  // IGNITION_MATH_PYTHON__VECTOR3_HH_

--- a/src/python_pybind11/src/Vector4.cc
+++ b/src/python_pybind11/src/Vector4.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+
+#include "Vector4.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathVector4(py::module &m, const std::string &typestr)
+{
+  helpDefineMathVector4<double>(m, typestr + "d");
+  helpDefineMathVector4<float>(m, typestr + "f");
+  helpDefineMathVector4<int>(m, typestr + "i");
+}
+
+}  // namespace python
+}  // namespace gazebo
+}  // namespace ignition

--- a/src/python_pybind11/src/Vector4.hh
+++ b/src/python_pybind11/src/Vector4.hh
@@ -15,8 +15,8 @@
  *
 */
 
-#ifndef IGNITION_MATH_PYTHON__VECTOR4D_HH_
-#define IGNITION_MATH_PYTHON__VECTOR4D_HH_
+#ifndef IGNITION_MATH_PYTHON__VECTOR4_HH_
+#define IGNITION_MATH_PYTHON__VECTOR4_HH_
 
 #include <string>
 
@@ -34,12 +34,12 @@ namespace math
 {
 namespace python
 {
-/// Define a pybind11 wrapper for an ignition::math::Vector4
+/// Help define a pybind11 wrapper for an ignition::math::Vector4
 /**
  * \param[in] module a pybind11 module to add the definition to
  */
 template<typename T>
-void defineMathVector4(py::module &m, const std::string &typestr)
+void helpDefineMathVector4(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::Vector4<T>;
   auto toString = [](const Class &si) {
@@ -145,8 +145,13 @@ void defineMathVector4(py::module &m, const std::string &typestr)
     .def("__repr__", toString);
 }
 
+/// Define a pybind11 wrapper for an ignition::math::Vector4
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ */
+void defineMathVector4(py::module &m, const std::string &typestr);
 }  // namespace python
 }  // namespace gazebo
 }  // namespace ignition
 
-#endif  // IGNITION_MATH_PYTHON__VECTOR4D_HH_
+#endif  // IGNITION_MATH_PYTHON__VECTOR4_HH_

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -126,9 +126,7 @@ PYBIND11_MODULE(math, m)
 
   ignition::math::python::defineMathLine2(m, "Line2");
 
-  ignition::math::python::defineMathLine3<int>(m, "Line3i");
-  ignition::math::python::defineMathLine3<double>(m, "Line3d");
-  ignition::math::python::defineMathLine3<float>(m, "Line3f");
+  ignition::math::python::defineMathLine3(m, "Line3");
 
   ignition::math::python::defineMathMatrix3<int>(m, "Matrix3i");
   ignition::math::python::defineMathMatrix3<double>(m, "Matrix3d");

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -169,20 +169,14 @@ PYBIND11_MODULE(math, m)
 
   ignition::math::python::defineMathFrustum(m, "Frustum");
 
-  ignition::math::python::defineMathFilter<int>(m, "Filteri");
-  ignition::math::python::defineMathFilter<float>(m, "Filterf");
-  ignition::math::python::defineMathFilter<double>(m, "Filterd");
+  ignition::math::python::defineMathFilter(m, "Filter");
 
-  ignition::math::python::defineMathBiQuad<int>(m, "BiQuadi");
-  ignition::math::python::defineMathBiQuad<float>(m, "BiQuadf");
-  ignition::math::python::defineMathBiQuad<double>(m, "BiQuadd");
+  ignition::math::python::defineMathBiQuad(m, "BiQuad");
 
   ignition::math::python::defineMathBiQuadVector3(
     m, "BiQuadVector3");
 
-  ignition::math::python::defineMathOnePole<int>(m, "OnePolei");
-  ignition::math::python::defineMathOnePole<float>(m, "OnePolef");
-  ignition::math::python::defineMathOnePole<double>(m, "OnePoled");
+  ignition::math::python::defineMathOnePole(m, "OnePole");
 
   ignition::math::python::defineMathOnePoleQuaternion(
     m, "OnePoleQuaternion");

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -124,9 +124,7 @@ PYBIND11_MODULE(math, m)
 
   ignition::math::python::defineMathVector4(m, "Vector4");
 
-  ignition::math::python::defineMathLine2<int>(m, "Line2i");
-  ignition::math::python::defineMathLine2<double>(m, "Line2d");
-  ignition::math::python::defineMathLine2<float>(m, "Line2f");
+  ignition::math::python::defineMathLine2(m, "Line2");
 
   ignition::math::python::defineMathLine3<int>(m, "Line3i");
   ignition::math::python::defineMathLine3<double>(m, "Line3d");

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -79,12 +79,7 @@ PYBIND11_MODULE(math, m)
 
   ignition::math::python::defineMathMaterial(m, "Material");
 
-  ignition::math::python::defineMathMovingWindowFilter<int>(
-    m, "MovingWindowFilteri");
-  ignition::math::python::defineMathMovingWindowFilter<double>(
-    m, "MovingWindowFilterd");
-  ignition::math::python::defineMathMovingWindowFilter
-    <ignition::math::Vector3d>(m, "MovingWindowFilterv3");
+  ignition::math::python::defineMathMovingWindowFilter(m, "MovingWindowFilter");
 
   ignition::math::python::defineMathPID(m, "PID");
 

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -120,18 +120,14 @@ PYBIND11_MODULE(math, m)
 
   ignition::math::python::defineMathVector2(m, "Vector2");
 
-  ignition::math::python::defineMathVector3<double>(m, "Vector3d");
-  ignition::math::python::defineMathVector3<int>(m, "Vector3i");
-  ignition::math::python::defineMathVector3<float>(m, "Vector3f");
+  ignition::math::python::defineMathVector3(m, "Vector3");
 
   ignition::math::python::defineMathPlane<double>(m, "Planed");
 
   ignition::math::python::defineMathBox<double>(m, "Boxd");
   ignition::math::python::defineMathBox<float>(m, "Boxf");
 
-  ignition::math::python::defineMathVector4<double>(m, "Vector4d");
-  ignition::math::python::defineMathVector4<int>(m, "Vector4i");
-  ignition::math::python::defineMathVector4<float>(m, "Vector4f");
+  ignition::math::python::defineMathVector4(m, "Vector4");
 
   ignition::math::python::defineMathLine2<int>(m, "Line2i");
   ignition::math::python::defineMathLine2<double>(m, "Line2d");


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to #371

## Summary

This continues moving template instantiations from `_ignition_math_pybind11.cc` to a separate translation unit for templates in each of the following header files:

* Filter.hh
* Line2.hh
* Line3.hh
* MovingWindowFilter.hh
* Vector3.hh
* Vector4.hh

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
