### PR TITLE
Fixes for tests on i386: relax SphericalCoordinates and workaround for negative zero

### DIFF
--- a/src/OrientedBox_TEST.cc
+++ b/src/OrientedBox_TEST.cc
@@ -332,12 +332,14 @@ TEST(OrientedBoxTest, OperatorStreamOut)
   std::ostringstream stream;
   stream << b;
 
-  // some compiler optimizations returns negative zero (-0) in the stream, workaround
-  // using prefix and postfix check. Not nice I know
-  EXPECT_TRUE(stream.str().find("Size[0.1 1.2 2.3] Pose[3.4 4.5 5.6") != std::string::npos) <<
-    "stream.str is: " << stream.str();
-  EXPECT_TRUE(stream.str().find("0 -0.1 0.2] Material[]") != std::string::npos) <<
-    "stream.str is: " << stream.str();
+  // some compiler optimizations returns negative zero (-0) in the stream,
+  // workaround using prefix and postfix check. Not nice I know
+  EXPECT_TRUE(stream.str().find(
+        "Size[0.1 1.2 2.3] Pose[3.4 4.5 5.6") != std::string::npos) <<
+          "stream.str is: " << stream.str();
+  EXPECT_TRUE(stream.str().find(
+        "0 -0.1 0.2] Material[]") != std::string::npos) <<
+          "stream.str is: " << stream.str();
 }
 
 //////////////////////////////////////////////////

--- a/src/OrientedBox_TEST.cc
+++ b/src/OrientedBox_TEST.cc
@@ -331,8 +331,13 @@ TEST(OrientedBoxTest, OperatorStreamOut)
                   Pose3d(3.4, 4.5, 5.6, 0.0, -0.1, 0.2));
   std::ostringstream stream;
   stream << b;
-  EXPECT_EQ(stream.str(),
-      "Size[0.1 1.2 2.3] Pose[3.4 4.5 5.6 0 -0.1 0.2] Material[]");
+
+  // some compiler optimizations returns negative zero (-0) in the stream, workaround
+  // using prefix and postfix check. Not nice I know
+  EXPECT_TRUE(stream.str().find("Size[0.1 1.2 2.3] Pose[3.4 4.5 5.6") != std::string::npos) <<
+    "stream.str is: " << stream.str();
+  EXPECT_TRUE(stream.str().find("0 -0.1 0.2] Material[]") != std::string::npos) <<
+    "stream.str is: " << stream.str();
 }
 
 //////////////////////////////////////////////////

--- a/src/OrientedBox_TEST.cc
+++ b/src/OrientedBox_TEST.cc
@@ -328,18 +328,12 @@ TEST(OrientedBoxTest, ContainsOrientedRotation)
 TEST(OrientedBoxTest, OperatorStreamOut)
 {
   OrientedBoxd b(Vector3d(0.1, 1.2, 2.3),
-                  Pose3d(3.4, 4.5, 5.6, 0.0, -0.1, 0.2));
+                  Pose3d(3.4, 4.5, 5.6, 0.1, -0.1, 0.2));
   std::ostringstream stream;
   stream << b;
 
-  // some compiler optimizations returns negative zero (-0) in the stream,
-  // workaround using prefix and postfix check. Not nice I know
-  EXPECT_TRUE(stream.str().find(
-        "Size[0.1 1.2 2.3] Pose[3.4 4.5 5.6") != std::string::npos) <<
-          "stream.str is: " << stream.str();
-  EXPECT_TRUE(stream.str().find(
-        "0 -0.1 0.2] Material[]") != std::string::npos) <<
-          "stream.str is: " << stream.str();
+  EXPECT_EQ(stream.str(),
+      "Size[0.1 1.2 2.3] Pose[3.4 4.5 5.6 0.1 -0.1 0.2] Material[]");
 }
 
 //////////////////////////////////////////////////

--- a/src/SphericalCoordinates_TEST.cc
+++ b/src/SphericalCoordinates_TEST.cc
@@ -448,7 +448,7 @@ TEST(SphericalCoordinatesTest, NoHeading)
   auto latLonAlt = sc.SphericalFromLocalPosition({0, 0, 0});
   EXPECT_DOUBLE_EQ(lat.Degree(), latLonAlt.X());
   EXPECT_DOUBLE_EQ(lon.Degree(), latLonAlt.Y());
-  EXPECT_DOUBLE_EQ(elev, latLonAlt.Z());
+  EXPECT_NEAR(elev, latLonAlt.Z(), 1e-6);
 
   auto xyzOrigin = sc.LocalFromSphericalPosition(latLonAlt);
   EXPECT_EQ(math::Vector3d::Zero, xyzOrigin);
@@ -556,7 +556,7 @@ TEST(SphericalCoordinatesTest, WithHeading)
   auto latLonAlt = sc.SphericalFromLocalPosition({0, 0, 0});
   EXPECT_DOUBLE_EQ(lat.Degree(), latLonAlt.X());
   EXPECT_DOUBLE_EQ(lon.Degree(), latLonAlt.Y());
-  EXPECT_DOUBLE_EQ(elev, latLonAlt.Z());
+  EXPECT_NEAR(elev, latLonAlt.Z(), 1e-6);
 
   auto xyzOrigin = sc.LocalFromSphericalPosition(latLonAlt);
   EXPECT_EQ(math::Vector3d::Zero, xyzOrigin);


### PR DESCRIPTION
Two changes to make i386 testing build happy after ign-math 6.10:
 *  OrientedBox_TEST: the problem appeared before, when comparing strings that comes from a zero value in maths, the optimizations in some platforms return a negative zero making the comparison to fail. The workaround is to compare the two substrings around the zero.
 * SphericalCoordinates_TEST: some float operations in i386 does not return the exact number but a really close one. Change the test to reflect this reality.