### PR TITLE
Fix output stream operator

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,7 @@
 1. Added Equal functions with a tolerance parameter to Pose3 and Quaternion.
     * [BitBucket pull request 319](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-math/pull-requests/319)
 
-1. Updates per issue #101.
+1. Updates per issue [#101](https://github.com/ignitionrobotics/ign-math/issues/101).
     * Matrix3: [BitBucket pull request 328](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-math/pull-requests/328)
     * Pose: [BitBucket pull request 329](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-math/pull-requests/329)
     * Quaternion: [BitBucket pull request 327](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-math/pull-requests/327)
@@ -32,18 +32,22 @@
 
 1. Defer regex construction to avoid static initialization.
     * [Pull request 289](https://github.com/ignitionrobotics/ign-math/pull/289)
-                       
+
 1. Defer Material::Predefined construction to avoid static initialization.
     * [Pull request 290](https://github.com/ignitionrobotics/ign-math/pull/290)
 
 1. Resolve cppcheck errors by adding explicit constructors and consts.
     * [Pull request 291](https://github.com/ignitionrobotics/ign-math/pull/291)
-                   
+
 1. Remove virtual from destructors of copyable classes.
     * [Pull request 293](https://github.com/ignitionrobotics/ign-math/pull/293)
 
 1. Use constexpr for simple static constants.
     * [Pull request 283](https://github.com/ignitionrobotics/ign-math/pull/283)
+
+1. Deprecated `appendToStream(std::ostream, T, int)`. Use `appendToStream(std::ostream, T)`
+instead.
+    * TODO(jennuine) add PR 
 
 ## Ignition Math 6.x
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -47,7 +47,7 @@
 
 1. Deprecated `appendToStream(std::ostream, T, int)`. Use `appendToStream(std::ostream, T)`
 instead.
-    * TODO(jennuine) add PR 
+    * [Pull request 376](https://github.com/ignitionrobotics/ign-math/pull/376)
 
 ## Ignition Math 6.x
 

--- a/Migration.md
+++ b/Migration.md
@@ -53,6 +53,10 @@ release will remove the deprecated code.
     + ***Deprecation:*** public: void W(T)
     + ***Replacement:*** public: void SetW(T)
 
+1. **Helpers.hh**
+    + **Deprecation:** template<typename T> inline void appendToStream(std::ostream, T, int)
+    + **Replacement:** template<typename T> inline void appendToStream(std::ostream, T)
+
 ### Modifications
 
 1. The out stream operator is guaranteed to return always plain 0 and not to
@@ -266,4 +270,3 @@ release will remove the deprecated code.
 
     + ***Deprecation:*** IGN_I64_INF
     + ***Replacement:*** ignition::math::INF_I64
-

--- a/include/ignition/math/Color.hh
+++ b/include/ignition/math/Color.hh
@@ -296,7 +296,7 @@ namespace ignition
           if (i > 0)
             _out << " ";
 
-          appendToStream(_out, _color[i], 6);
+          appendToStream(_out, _color[i]);
         }
         return _out;
       }

--- a/include/ignition/math/Helpers.hh
+++ b/include/ignition/math/Helpers.hh
@@ -463,8 +463,10 @@ namespace ignition
     /// \param[out] _out Output stream.
     /// \param[in] _number Number to append.
     /// \param[in] _precision Precision for floating point numbers.
+    /// \deprecated Use appendToStream(std::ostream, T) instead.
     template<typename T>
-    inline void appendToStream(std::ostream &_out, T _number, int _precision)
+    inline void IGN_DEPRECATED(7) appendToStream(
+        std::ostream &_out, T _number, int _precision)
     {
       if (std::fpclassify(_number) == FP_ZERO)
       {
@@ -473,6 +475,22 @@ namespace ignition
       else
       {
         _out << precision(_number, _precision);
+      }
+    }
+
+    /// \brief Append a number to a stream. Makes sure "-0" is returned as "0".
+    /// \param[out] _out Output stream.
+    /// \param[in] _number Number to append.
+    template<typename T>
+    inline void appendToStream(std::ostream &_out, T _number)
+    {
+      if (std::fpclassify(_number) == FP_ZERO)
+      {
+        _out << 0;
+      }
+      else
+      {
+        _out << _number;
       }
     }
 

--- a/include/ignition/math/Helpers.hh
+++ b/include/ignition/math/Helpers.hh
@@ -478,6 +478,18 @@ namespace ignition
       }
     }
 
+    /// \brief Append a number to a stream, specialized for int.
+    /// \param[out] _out Output stream.
+    /// \param[in] _number Number to append.
+    /// _precision Not used for int.
+    /// \deprecated Use appendToStream(std::ostream, int) instead.
+    template<>
+    inline void IGN_DEPRECATED(7) appendToStream(
+        std::ostream &_out, int _number, int)
+    {
+      _out << _number;
+    }
+
     /// \brief Append a number to a stream. Makes sure "-0" is returned as "0".
     /// \param[out] _out Output stream.
     /// \param[in] _number Number to append.
@@ -497,9 +509,8 @@ namespace ignition
     /// \brief Append a number to a stream, specialized for int.
     /// \param[out] _out Output stream.
     /// \param[in] _number Number to append.
-    //  _precision Not used for int.
     template<>
-    inline void appendToStream(std::ostream &_out, int _number, int)
+    inline void appendToStream(std::ostream &_out, int _number)
     {
       _out << _number;
     }

--- a/include/ignition/math/Matrix3.hh
+++ b/include/ignition/math/Matrix3.hh
@@ -604,7 +604,7 @@ namespace ignition
             if (!(i == 0 && j == 0))
               _out << " ";
 
-            appendToStream(_out, _m(i, j), 6);
+            appendToStream(_out, _m(i, j));
           }
         }
 

--- a/include/ignition/math/Matrix4.hh
+++ b/include/ignition/math/Matrix4.hh
@@ -759,7 +759,7 @@ namespace ignition
             if (!(i == 0 && j == 0))
               _out << " ";
 
-            appendToStream(_out, _m(i, j), 6);
+            appendToStream(_out, _m(i, j));
           }
         }
 

--- a/include/ignition/math/Vector2.hh
+++ b/include/ignition/math/Vector2.hh
@@ -538,7 +538,7 @@ namespace ignition
           if (i > 0)
             _out << " ";
 
-          appendToStream(_out, _pt[i], 6);
+          appendToStream(_out, _pt[i]);
         }
         return _out;
       }

--- a/include/ignition/math/Vector3.hh
+++ b/include/ignition/math/Vector3.hh
@@ -736,7 +736,7 @@ namespace ignition
           if (i > 0)
             _out << " ";
 
-          appendToStream(_out, _pt[i], 6);
+          appendToStream(_out, _pt[i]);
         }
 
         return _out;

--- a/include/ignition/math/Vector4.hh
+++ b/include/ignition/math/Vector4.hh
@@ -696,7 +696,7 @@ namespace ignition
           if (i > 0)
             _out << " ";
 
-          appendToStream(_out, _pt[i], 6);
+          appendToStream(_out, _pt[i]);
         }
         return _out;
       }

--- a/src/Color_TEST.cc
+++ b/src/Color_TEST.cc
@@ -330,10 +330,22 @@ TEST(Color, ConstAndSet)
 /////////////////////////////////////////////////
 TEST(Color, OperatorStreamOut)
 {
-  math::Color c(0.1f, 0.2f, 0.3f, 0.0f);
+  math::Color c(0.1111f, 0.2222f, 0.3333f, 0.5555f);
   std::ostringstream stream;
   stream << c;
-  EXPECT_EQ(stream.str(), "0.1 0.2 0.3 0");
+  EXPECT_EQ(stream.str(), "0.1111 0.2222 0.3333 0.5555");
+
+  stream.str("");
+  stream << std::setprecision(2) << c;
+  EXPECT_EQ(stream.str(), "0.11 0.22 0.33 0.56");
+
+  stream.str("");
+  stream << std::setprecision(3) << c;
+  EXPECT_EQ(stream.str(), "0.111 0.222 0.333 0.555");
+
+  stream.str("");
+  stream << std::setprecision(1) << std::fixed << c;
+  EXPECT_EQ(stream.str(), "0.1 0.2 0.3 0.6");
 }
 
 /////////////////////////////////////////////////

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -1021,11 +1021,19 @@ TEST(HelpersTest, AppendToStream)
       << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
 
   math::appendToStream(out, pi);
+#ifdef _WIN32
+  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793");
+#else
   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239");
+#endif
 
   out << " "
       << std::setprecision(3);
 
   math::appendToStream(out, pi);
+#ifdef _WIN32
+  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793 3.14");
+#else
   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239 3.14");
+#endif
 }

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -24,6 +24,7 @@
 #include "ignition/math/Rand.hh"
 #include "ignition/math/Vector3.hh"
 #include "ignition/math/Helpers.hh"
+#include <ignition/utils/SuppressWarning.hh>
 
 using namespace ignition;
 
@@ -966,6 +967,29 @@ TEST(HelpersTest, roundUpMultiple)
 TEST(HelpersTest, AppendToStream)
 {
   std::ostringstream out;
+
+  IGN_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+  // Deprecated in ign-math7
+  math::appendToStream(out, 0.12345678, 3);
+  EXPECT_EQ(out.str(), "0.123");
+
+  out << " ";
+
+  math::appendToStream(out, 0.0f, 5);
+  EXPECT_EQ(out.str(), "0.123 0");
+
+  out << " ";
+
+  math::appendToStream(out, 456, 3);
+  EXPECT_EQ(out.str(), "0.123 0 456");
+
+  out << " ";
+
+  math::appendToStream(out, 0, 3);
+  EXPECT_EQ(out.str(), "0.123 0 456 0");
+
+  out.str("");
+  IGN_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 
   math::appendToStream(out, 0.0f);
   EXPECT_EQ(out.str(), "0");

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -17,6 +17,10 @@
 
 #include <gtest/gtest.h>
 
+#include <iomanip>
+#include <cmath>
+#include <limits>
+
 #include "ignition/math/Rand.hh"
 #include "ignition/math/Vector3.hh"
 #include "ignition/math/Helpers.hh"
@@ -963,21 +967,41 @@ TEST(HelpersTest, AppendToStream)
 {
   std::ostringstream out;
 
-  math::appendToStream(out, 0.12345678, 3);
-  EXPECT_EQ(out.str(), "0.123");
+  math::appendToStream(out, 0.0f);
+  EXPECT_EQ(out.str(), "0");
 
   out << " ";
 
-  math::appendToStream(out, 0.0f, 5);
-  EXPECT_EQ(out.str(), "0.123 0");
+  math::appendToStream(out, 456);
+  EXPECT_EQ(out.str(), "0 456");
 
   out << " ";
 
-  math::appendToStream(out, 456, 3);
-  EXPECT_EQ(out.str(), "0.123 0 456");
+  math::appendToStream(out, 0);
+  EXPECT_EQ(out.str(), "0 456 0");
 
   out << " ";
 
-  math::appendToStream(out, 0, 3);
-  EXPECT_EQ(out.str(), "0.123 0 456 0");
+  // ref: https://en.cppreference.com/w/cpp/io/manip/setprecision
+  const long double pi = std::acos(-1.L);
+  math::appendToStream(out, pi);
+  EXPECT_EQ(out.str(), "0 456 0 3.14159");
+
+  out << " "
+      << std::setprecision(10);
+
+  math::appendToStream(out, pi);
+  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654");
+
+  out << " "
+      << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
+
+  math::appendToStream(out, pi);
+  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239");
+
+  out << " "
+      << std::setprecision(3);
+
+  math::appendToStream(out, pi);
+  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239 3.14");
 }

--- a/src/Matrix3_TEST.cc
+++ b/src/Matrix3_TEST.cc
@@ -160,13 +160,26 @@ TEST(Matrix3dTest, OperatorMul)
 /////////////////////////////////////////////////
 TEST(Matrix3dTest, OperatorStreamOut)
 {
-  math::Matrix3d matA(1, 2, 3,
-                      4, 0, 6,
-                      7, 8, 9);
+  math::Matrix3d matA(1.111, 2.222, 3.333,
+                      4.444, 0.001, 6.666,
+                      7.777, 8.888, 9.999);
 
   std::ostringstream stream;
   stream << matA;
-  EXPECT_EQ(stream.str(), "1 2 3 4 0 6 7 8 9");
+  EXPECT_EQ(stream.str(),
+            "1.111 2.222 3.333 4.444 0.001 6.666 7.777 8.888 9.999");
+
+  stream.str("");
+  stream << std::setprecision(2) << matA;
+  EXPECT_EQ(stream.str(), "1.1 2.2 3.3 4.4 0.001 6.7 7.8 8.9 10");
+
+  stream.str("");
+  stream << std::setprecision(3) << matA;
+  EXPECT_EQ(stream.str(), "1.11 2.22 3.33 4.44 0.001 6.67 7.78 8.89 10");
+
+  stream.str("");
+  stream << std::setprecision(1) << std::fixed << matA;
+  EXPECT_EQ(stream.str(), "1.1 2.2 3.3 4.4 0.0 6.7 7.8 8.9 10.0");
 }
 
 /////////////////////////////////////////////////

--- a/src/Matrix4_TEST.cc
+++ b/src/Matrix4_TEST.cc
@@ -17,9 +17,9 @@
 
 #include <gtest/gtest.h>
 
+#include "ignition/math/Matrix4.hh"
 #include "ignition/math/Pose3.hh"
 #include "ignition/math/Quaternion.hh"
-#include "ignition/math/Matrix4.hh"
 #include "ignition/math/Vector3.hh"
 
 using namespace ignition;
@@ -542,14 +542,33 @@ TEST(Matrix4dTest, NoIndexException)
 /////////////////////////////////////////////////
 TEST(Matrix4dTest, OperatorStreamOut)
 {
-  math::Matrix4d matA(1, 2, 3, 4,
-                      5, 6, 7, 8,
-                      9, 10, 11, 12,
-                      13, 14, 15, 0);
+  math::Matrix4d matA(1.111, 2.222, 3.333, 4.444,
+                      5.555, 6.666, 7.777, 8.888,
+                      9.999, 10.01, 11.11, 12.12,
+                      13.13, 14.14, 15.15, 0.001);
 
   std::ostringstream stream;
   stream << matA;
-  EXPECT_EQ(stream.str(), "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 0");
+  EXPECT_EQ(stream.str(),
+            "1.111 2.222 3.333 4.444 5.555 6.666 7.777 8.888 9.999 10.01"
+            " 11.11 12.12 13.13 14.14 15.15 0.001");
+
+  stream.str("");
+  stream << std::setprecision(2) << matA;
+  EXPECT_EQ(stream.str(),
+            "1.1 2.2 3.3 4.4 5.6 6.7 7.8 8.9 10 10 11 12 13 14 15 0.001");
+
+  stream.str("");
+  stream << std::setprecision(3) << matA;
+  EXPECT_EQ(stream.str(),
+            "1.11 2.22 3.33 4.44 5.55 6.67 7.78 8.89 10 10"
+            " 11.1 12.1 13.1 14.1 15.2 0.001");
+
+  stream.str("");
+  stream << std::setprecision(1) << std::fixed << matA;
+  EXPECT_EQ(stream.str(),
+            "1.1 2.2 3.3 4.4 5.6 6.7 7.8 8.9 10.0 10.0"
+            " 11.1 12.1 13.1 14.1 15.2 0.0");
 }
 
 /////////////////////////////////////////////////

--- a/src/OrientedBox_TEST.cc
+++ b/src/OrientedBox_TEST.cc
@@ -328,11 +328,11 @@ TEST(OrientedBoxTest, ContainsOrientedRotation)
 TEST(OrientedBoxTest, OperatorStreamOut)
 {
   OrientedBoxd b(Vector3d(0.1, 1.2, 2.3),
-                  Pose3d(3.4, 4.5, 5.6, 0.0, -0.1, 0.2));
+                  Pose3d(3.4, 4.5, 5.6, 0.1, -0.1, 0.2));
   std::ostringstream stream;
   stream << b;
   EXPECT_EQ(stream.str(),
-      "Size[0.1 1.2 2.3] Pose[3.4 4.5 5.6 0 -0.1 0.2] Material[]");
+      "Size[0.1 1.2 2.3] Pose[3.4 4.5 5.6 0.1 -0.1 0.2] Material[]");
 }
 
 //////////////////////////////////////////////////

--- a/src/Vector2_TEST.cc
+++ b/src/Vector2_TEST.cc
@@ -296,9 +296,21 @@ TEST(Vector2Test, AbsDot)
 /////////////////////////////////////////////////
 TEST(Vector2Test, OperatorStreamOut)
 {
-  math::Vector2d v(0.1, 1.2);
+  math::Vector2d v(0.1234, 1.234);
   std::ostringstream stream;
   stream << v;
+  EXPECT_EQ(stream.str(), "0.1234 1.234");
+
+  stream.str("");
+  stream << std::setprecision(2) << v;
+  EXPECT_EQ(stream.str(), "0.12 1.2");
+
+  stream.str("");
+  stream << std::setprecision(3) << v;
+  EXPECT_EQ(stream.str(), "0.123 1.23");
+
+  stream.str("");
+  stream << std::setprecision(1) << std::fixed << v;
   EXPECT_EQ(stream.str(), "0.1 1.2");
 }
 
@@ -464,4 +476,3 @@ TEST(Vector2Test, NaN)
   EXPECT_EQ(math::Vector2f::Zero, nanVecF);
   EXPECT_TRUE(nanVecF.IsFinite());
 }
-

--- a/src/Vector3_TEST.cc
+++ b/src/Vector3_TEST.cc
@@ -20,8 +20,8 @@
 #include <numeric>
 #include <sstream>
 
-#include "ignition/math/Vector3.hh"
 #include "ignition/math/Helpers.hh"
+#include "ignition/math/Vector3.hh"
 
 using namespace ignition;
 
@@ -555,4 +555,25 @@ TEST(Vector3dTest, DistToLine)
     math::Vector3d point(0, 2, 0);
     EXPECT_DOUBLE_EQ(point.DistToLine(pointA, pointB), 0);
   }
+}
+
+/////////////////////////////////////////////////
+TEST(Vector3dTest, OperatorStreamOut)
+{
+  math::Vector3d v(0.1234, 1.234, 2.3456);
+  std::ostringstream stream;
+  stream << v;
+  EXPECT_EQ(stream.str(), "0.1234 1.234 2.3456");
+
+  stream.str("");
+  stream << std::setprecision(2) << v;
+  EXPECT_EQ(stream.str(), "0.12 1.2 2.3");
+
+  stream.str("");
+  stream << std::setprecision(3) << v;
+  EXPECT_EQ(stream.str(), "0.123 1.23 2.35");
+
+  stream.str("");
+  stream << std::setprecision(1) << std::fixed << v;
+  EXPECT_EQ(stream.str(), "0.1 1.2 2.3");
 }

--- a/src/Vector4_TEST.cc
+++ b/src/Vector4_TEST.cc
@@ -379,9 +379,21 @@ TEST(Vector4dTest, Sub)
 /////////////////////////////////////////////////
 TEST(Vector4dTest, OperatorStreamOut)
 {
-  math::Vector4d v(0.1, 1.2, 2.3, 0.0);
+  math::Vector4d v(0.1234, 1.234, 2.3456, 0.0);
   std::ostringstream stream;
   stream << v;
+  EXPECT_EQ(stream.str(), "0.1234 1.234 2.3456 0");
+
+  stream.str("");
+  stream << std::setprecision(2) << v;
+  EXPECT_EQ(stream.str(), "0.12 1.2 2.3 0");
+
+  stream.str("");
+  stream << std::setprecision(3) << v;
+  EXPECT_EQ(stream.str(), "0.123 1.23 2.35 0");
+
+  stream.str("");
+  stream << std::setprecision(1) << std::fixed << v;
   EXPECT_EQ(stream.str(), "0.1 1.2 2.3 0");
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/ignitionrobotics/sdformat/issues/790

(See section (2) of https://github.com/ignitionrobotics/sdformat/issues/790#issuecomment-1026187429)

## Summary
The output stream would change the value when [calling `precision()`](https://github.com/ignitionrobotics/ign-math/blob/6761d32609c67c63d138feac07086571b9b5ac16/include/ignition/math/Helpers.hh#L475). This causes issues changing the precision of the output stream.

For example,
 
```c++
math::Vector3d test(1.5707963267948966, 0, 0);
std::cout << test;
// prints 1.5708 0 0

std::cout << std::setprecision(std::numeric_limits<double>::digits10) 
              << test; 
// prints 1.5707960000000001 0 0; x should be 1.5707963267949
```

Since there doesn't seem to be a clear reason to why the value is changed and the default precision is already 6, I've deprecated the function that changes the value `appendToStream(std::ostream &_out, T _number, int _precision)` to be replaced with `appendToStream(std::ostream &_out, T _number)`. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.