### PR TITLE
Reduce pybind11 compilation memory part 3

### DIFF
--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -26,6 +26,7 @@ pybind11_add_module(math SHARED
   src/Matrix4.cc
   src/MovingWindowFilter.cc
   src/PID.cc
+  src/Quaternion.cc
   src/Rand.cc
   src/RollingMean.cc
   src/RotationSpline.cc

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -37,6 +37,7 @@ pybind11_add_module(math SHARED
   src/Spline.cc
   src/StopWatch.cc
   src/Temperature.cc
+  src/Triangle.cc
   src/Triangle3.cc
   src/Vector2.cc
   src/Vector3.cc

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -21,6 +21,7 @@ pybind11_add_module(math SHARED
   src/Line2.cc
   src/Line3.cc
   src/Material.cc
+  src/Matrix3.cc
   src/MovingWindowFilter.cc
   src/PID.cc
   src/Rand.cc

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -26,6 +26,7 @@ pybind11_add_module(math SHARED
   src/Matrix4.cc
   src/MovingWindowFilter.cc
   src/PID.cc
+  src/Pose3.cc
   src/Quaternion.cc
   src/Rand.cc
   src/RollingMean.cc

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -20,6 +20,7 @@ pybind11_add_module(math SHARED
   src/Kmeans.cc
   src/Line2.cc
   src/Line3.cc
+  src/MassMatrix3.cc
   src/Material.cc
   src/Matrix3.cc
   src/Matrix4.cc

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -22,6 +22,7 @@ pybind11_add_module(math SHARED
   src/Line3.cc
   src/Material.cc
   src/Matrix3.cc
+  src/Matrix4.cc
   src/MovingWindowFilter.cc
   src/PID.cc
   src/Rand.cc

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -37,6 +37,7 @@ pybind11_add_module(math SHARED
   src/Spline.cc
   src/StopWatch.cc
   src/Temperature.cc
+  src/Triangle3.cc
   src/Vector2.cc
   src/Vector3.cc
   src/Vector4.cc

--- a/src/python_pybind11/src/MassMatrix3.cc
+++ b/src/python_pybind11/src/MassMatrix3.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+
+#include "MassMatrix3.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathMassMatrix3(py::module &m, const std::string &typestr)
+{
+  helpDefineMathMassMatrix3<double>(m, typestr + "d");
+  helpDefineMathMassMatrix3<float>(m, typestr + "f");
+}
+
+}  // namespace python
+}  // namespace gazebo
+}  // namespace ignition

--- a/src/python_pybind11/src/MassMatrix3.hh
+++ b/src/python_pybind11/src/MassMatrix3.hh
@@ -38,8 +38,15 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
+void defineMathMassMatrix3(py::module &m, const std::string &typestr);
+
+/// Help define a pybind11 wrapper for an ignition::math::MassMatrix3
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
 template<typename T>
-void defineMathMassMatrix3(py::module &m, const std::string &typestr)
+void helpDefineMathMassMatrix3(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::MassMatrix3<T>;
   std::string pyclass_name = typestr;

--- a/src/python_pybind11/src/Matrix3.cc
+++ b/src/python_pybind11/src/Matrix3.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+
+#include "Matrix3.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathMatrix3(py::module &m, const std::string &typestr)
+{
+  helpDefineMathMatrix3<double>(m, typestr + "d");
+  helpDefineMathMatrix3<float>(m, typestr + "f");
+  helpDefineMathMatrix3<int>(m, typestr + "i");
+}
+
+}  // namespace python
+}  // namespace gazebo
+}  // namespace ignition

--- a/src/python_pybind11/src/Matrix3.hh
+++ b/src/python_pybind11/src/Matrix3.hh
@@ -39,8 +39,15 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
+void defineMathMatrix3(py::module &m, const std::string &typestr);
+
+/// Help define a pybind11 wrapper for an ignition::math::Matrix3
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
 template<typename T>
-void defineMathMatrix3(py::module &m, const std::string &typestr)
+void helpDefineMathMatrix3(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::Matrix3<T>;
   auto toString = [](const Class &si) {

--- a/src/python_pybind11/src/Matrix4.cc
+++ b/src/python_pybind11/src/Matrix4.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+
+#include "Matrix4.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathMatrix4(py::module &m, const std::string &typestr)
+{
+  helpDefineMathMatrix4<double>(m, typestr + "d");
+  helpDefineMathMatrix4<float>(m, typestr + "f");
+  helpDefineMathMatrix4<int>(m, typestr + "i");
+}
+
+}  // namespace python
+}  // namespace gazebo
+}  // namespace ignition

--- a/src/python_pybind11/src/Matrix4.hh
+++ b/src/python_pybind11/src/Matrix4.hh
@@ -39,8 +39,15 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
+void defineMathMatrix4(py::module &m, const std::string &typestr);
+
+/// Define a pybind11 wrapper for an ignition::math::Matrix4
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
 template<typename T>
-void defineMathMatrix4(py::module &m, const std::string &typestr)
+void helpDefineMathMatrix4(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::Matrix4<T>;
   auto toString = [](const Class &si) {

--- a/src/python_pybind11/src/Pose3.cc
+++ b/src/python_pybind11/src/Pose3.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+
+#include "Pose3.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathPose3(py::module &m, const std::string &typestr)
+{
+  helpDefineMathPose3<double>(m, typestr + "d");
+  helpDefineMathPose3<float>(m, typestr + "f");
+  helpDefineMathPose3<int>(m, typestr + "i");
+}
+
+}  // namespace python
+}  // namespace gazebo
+}  // namespace ignition

--- a/src/python_pybind11/src/Pose3.hh
+++ b/src/python_pybind11/src/Pose3.hh
@@ -39,8 +39,15 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
+void defineMathPose3(py::module &m, const std::string &typestr);
+
+/// Help define a pybind11 wrapper for an ignition::math::Pose3
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
 template<typename T>
-void defineMathPose3(py::module &m, const std::string &typestr)
+void helpDefineMathPose3(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::Pose3<T>;
   auto toString = [](const Class &si) {

--- a/src/python_pybind11/src/Quaternion.cc
+++ b/src/python_pybind11/src/Quaternion.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+
+#include "Quaternion.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathQuaternion(py::module &m, const std::string &typestr)
+{
+  helpDefineMathQuaternion<double>(m, typestr + "d");
+  helpDefineMathQuaternion<float>(m, typestr + "f");
+  helpDefineMathQuaternion<int>(m, typestr + "i");
+}
+
+}  // namespace python
+}  // namespace gazebo
+}  // namespace ignition

--- a/src/python_pybind11/src/Quaternion.hh
+++ b/src/python_pybind11/src/Quaternion.hh
@@ -42,8 +42,15 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
+void defineMathQuaternion(py::module &m, const std::string &typestr);
+
+/// Help define a pybind11 wrapper for an ignition::math::Quaternion
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
 template<typename T>
-void defineMathQuaternion(py::module &m, const std::string &typestr)
+void helpDefineMathQuaternion(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::Quaternion<T>;
   auto toString = [](const Class &si) {

--- a/src/python_pybind11/src/Triangle.cc
+++ b/src/python_pybind11/src/Triangle.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+
+#include "Triangle.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathTriangle(py::module &m, const std::string &typestr)
+{
+  helpDefineMathTriangle<double>(m, typestr + "d");
+  helpDefineMathTriangle<float>(m, typestr + "f");
+  helpDefineMathTriangle<int>(m, typestr + "i");
+}
+
+}  // namespace python
+}  // namespace gazebo
+}  // namespace ignition

--- a/src/python_pybind11/src/Triangle.hh
+++ b/src/python_pybind11/src/Triangle.hh
@@ -39,8 +39,15 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
+void defineMathTriangle(py::module &m, const std::string &typestr);
+
+/// Help define a pybind11 wrapper for an ignition::math::Triangle
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
 template<typename T>
-void defineMathTriangle(py::module &m, const std::string &typestr)
+void helpDefineMathTriangle(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::Triangle<T>;
   py::class_<Class>(m,

--- a/src/python_pybind11/src/Triangle3.cc
+++ b/src/python_pybind11/src/Triangle3.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+
+#include "Triangle3.hh"
+
+namespace ignition
+{
+namespace math
+{
+namespace python
+{
+void defineMathTriangle3(py::module &m, const std::string &typestr)
+{
+  helpDefineMathTriangle3<double>(m, typestr + "d");
+  helpDefineMathTriangle3<float>(m, typestr + "f");
+  helpDefineMathTriangle3<int>(m, typestr + "i");
+}
+
+}  // namespace python
+}  // namespace gazebo
+}  // namespace ignition

--- a/src/python_pybind11/src/Triangle3.hh
+++ b/src/python_pybind11/src/Triangle3.hh
@@ -39,8 +39,15 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  * \param[in] typestr name of the type used by Python
  */
+void defineMathTriangle3(py::module &m, const std::string &typestr);
+
+/// Help define a pybind11 wrapper for an ignition::math::Triangle3
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
 template<typename T>
-void defineMathTriangle3(py::module &m, const std::string &typestr)
+void helpDefineMathTriangle3(py::module &m, const std::string &typestr)
 {
   using Class = ignition::math::Triangle3<T>;
   py::class_<Class>(m,

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -132,9 +132,7 @@ PYBIND11_MODULE(math, m)
 
   ignition::math::python::defineMathMatrix4(m, "Matrix4");
 
-  ignition::math::python::defineMathTriangle<int>(m, "Trianglei");
-  ignition::math::python::defineMathTriangle<double>(m, "Triangled");
-  ignition::math::python::defineMathTriangle<float>(m, "Trianglef");
+  ignition::math::python::defineMathTriangle(m, "Triangle");
 
   ignition::math::python::defineMathTriangle3(m, "Triangle3");
 

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -130,9 +130,7 @@ PYBIND11_MODULE(math, m)
 
   ignition::math::python::defineMathMatrix3(m, "Matrix3");
 
-  ignition::math::python::defineMathMatrix4<int>(m, "Matrix4i");
-  ignition::math::python::defineMathMatrix4<double>(m, "Matrix4d");
-  ignition::math::python::defineMathMatrix4<float>(m, "Matrix4f");
+  ignition::math::python::defineMathMatrix4(m, "Matrix4");
 
   ignition::math::python::defineMathTriangle<int>(m, "Trianglei");
   ignition::math::python::defineMathTriangle<double>(m, "Triangled");

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -150,8 +150,7 @@ PYBIND11_MODULE(math, m)
   ignition::math::python::defineMathPose3<double>(m, "Pose3d");
   ignition::math::python::defineMathPose3<float>(m, "Pose3f");
 
-  ignition::math::python::defineMathMassMatrix3<double>(m, "MassMatrix3d");
-  ignition::math::python::defineMathMassMatrix3<float>(m, "MassMatrix3f");
+  ignition::math::python::defineMathMassMatrix3(m, "MassMatrix3");
 
   ignition::math::python::defineMathSphere<double>(m, "Sphered");
 

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -144,9 +144,7 @@ PYBIND11_MODULE(math, m)
 
   ignition::math::python::defineMathOrientedBox<double>(m, "OrientedBoxd");
 
-  ignition::math::python::defineMathPose3<int>(m, "Pose3i");
-  ignition::math::python::defineMathPose3<double>(m, "Pose3d");
-  ignition::math::python::defineMathPose3<float>(m, "Pose3f");
+  ignition::math::python::defineMathPose3(m, "Pose3");
 
   ignition::math::python::defineMathMassMatrix3(m, "MassMatrix3");
 

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -128,9 +128,7 @@ PYBIND11_MODULE(math, m)
 
   ignition::math::python::defineMathLine3(m, "Line3");
 
-  ignition::math::python::defineMathMatrix3<int>(m, "Matrix3i");
-  ignition::math::python::defineMathMatrix3<double>(m, "Matrix3d");
-  ignition::math::python::defineMathMatrix3<float>(m, "Matrix3f");
+  ignition::math::python::defineMathMatrix3(m, "Matrix3");
 
   ignition::math::python::defineMathMatrix4<int>(m, "Matrix4i");
   ignition::math::python::defineMathMatrix4<double>(m, "Matrix4d");

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -140,9 +140,7 @@ PYBIND11_MODULE(math, m)
   ignition::math::python::defineMathTriangle3<double>(m, "Triangle3d");
   ignition::math::python::defineMathTriangle3<float>(m, "Triangle3f");
 
-  ignition::math::python::defineMathQuaternion<int>(m, "Quaternioni");
-  ignition::math::python::defineMathQuaternion<double>(m, "Quaterniond");
-  ignition::math::python::defineMathQuaternion<float>(m, "Quaternionf");
+  ignition::math::python::defineMathQuaternion(m, "Quaternion");
 
   ignition::math::python::defineMathOrientedBox<double>(m, "OrientedBoxd");
 

--- a/src/python_pybind11/src/_ignition_math_pybind11.cc
+++ b/src/python_pybind11/src/_ignition_math_pybind11.cc
@@ -136,9 +136,7 @@ PYBIND11_MODULE(math, m)
   ignition::math::python::defineMathTriangle<double>(m, "Triangled");
   ignition::math::python::defineMathTriangle<float>(m, "Trianglef");
 
-  ignition::math::python::defineMathTriangle3<int>(m, "Triangle3i");
-  ignition::math::python::defineMathTriangle3<double>(m, "Triangle3d");
-  ignition::math::python::defineMathTriangle3<float>(m, "Triangle3f");
+  ignition::math::python::defineMathTriangle3(m, "Triangle3");
 
   ignition::math::python::defineMathQuaternion(m, "Quaternion");
 


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to #371 and #373.

## Summary

This continues moving template instantiations from _ignition_math_pybind11.cc to a separate translation unit for templates in each of the following header files:

* MassMatrix3.hh
* Matrix3.hh
* Matrix4.hh
* Pose3.hh
* Quaternion.hh
* Triangle.hh
* Triangle3.hh

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
