### PR TITLE
Support polynomial piecewise scalar fields

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -36,6 +36,9 @@ target_link_libraries(kmeans ignition-math${IGN_MATH_VER}::ignition-math${IGN_MA
 add_executable(matrix3_example matrix3_example.cc)
 target_link_libraries(matrix3_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
 
+add_executable(piecewise_scalar_field3_example piecewise_scalar_field3_example.cc)
+target_link_libraries(piecewise_scalar_field3_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
+
 add_executable(polynomial3_example polynomial3_example.cc)
 target_link_libraries(polynomial3_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -33,6 +33,9 @@ target_link_libraries(kmeans ignition-math${IGN_MATH_VER}::ignition-math${IGN_MA
 add_executable(matrix3_example matrix3_example.cc)
 target_link_libraries(matrix3_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
 
+add_executable(polynomial3_example polynomial3_example.cc)
+target_link_libraries(polynomial3_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
+
 add_executable(pose3_example pose3_example.cc)
 target_link_libraries(pose3_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -48,6 +48,9 @@ target_link_libraries(quaternion_to_euler ignition-math${IGN_MATH_VER}::ignition
 add_executable(rand_example rand_example.cc)
 target_link_libraries(rand_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
 
+add_executable(region3_example region3_example.cc)
+target_link_libraries(region3_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
+
 add_executable(temperature_example temperature_example.cc)
 target_link_libraries(temperature_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,6 +6,9 @@ project(ignition-math-examples)
 set(IGN_MATH_VER 7)
 find_package(ignition-math${IGN_MATH_VER} REQUIRED)
 
+add_executable(additively_separable_scalar_field3_example additively_separable_scalar_field3_example.cc)
+target_link_libraries(additively_separable_scalar_field3_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
+
 add_executable(angle_example angle_example.cc)
 target_link_libraries(angle_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,6 +24,9 @@ target_link_libraries(graph_example ignition-math${IGN_MATH_VER}::ignition-math$
 add_executable(helpers_example helpers_example.cc)
 target_link_libraries(helpers_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
 
+add_executable(interval_example interval_example.cc)
+target_link_libraries(interval_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
+
 add_executable(kmeans kmeans.cc)
 target_link_libraries(kmeans ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
 

--- a/examples/additively_separable_scalar_field3_example.cc
+++ b/examples/additively_separable_scalar_field3_example.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+//! [complete]
+#include <iostream>
+#include <ignition/math/AdditivelySeparableScalarField3.hh>
+#include <ignition/math/Polynomial3.hh>
+
+int main(int argc, char **argv)
+{
+  const double k = 1.;
+  const ignition::math::Polynomial3d px(
+      ignition::math::Vector4d(0., 1., 0., 1.));
+  const ignition::math::Polynomial3d qy(
+      ignition::math::Vector4d(1., 0., 1., 0.));
+  const ignition::math::Polynomial3d rz(
+      ignition::math::Vector4d(1., 0., 0., -1.));
+  using AdditivelySeparableScalarField3dT =
+      ignition::math::AdditivelySeparableScalarField3d<
+        ignition::math::Polynomial3d>;
+  const AdditivelySeparableScalarField3dT F(k, px, qy, rz);
+
+  // A printable, additively separable scalar field.
+  std::cout << "An additively separable scalar field in R^3 "
+            << "can be expressed as a sum of scalar functions "
+            << "e.g. F(x, y, z) = " << F << std::endl;
+
+  // An additively separable scalar field can be evaluated.
+  std::cout << "Evaluating F(x, y, z) at (0, 1, 0) yields "
+            << F(ignition::math::Vector3d::UnitY) << std::endl;
+
+  // An additively separable scalar field can be queried for its
+  // minimum (provided the underlying scalar function allows it).
+  std::cout << "The global minimum of F(x, y, z) is "
+            << F.Minimum() << std::endl;
+}
+//! [complete]

--- a/examples/interval_example.cc
+++ b/examples/interval_example.cc
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+//! [complete]
+#include <iostream>
+#include <ignition/math/Interval.hh>
+
+int main(int argc, char **argv)
+{
+  std::cout << std::boolalpha;
+
+  const ignition::math::Intervald defaultInterval;
+  // A default constructed interval should be empty.
+  std::cout << "The " << defaultInterval << " interval is empty: "
+            << defaultInterval.Empty() << std::endl;
+
+  const ignition::math::Intervald openInterval =
+      ignition::math::Intervald::Open(-1., 1.);
+  // An open interval should exclude its endpoints.
+  std::cout << "The " << openInterval << " interval contains its endpoints: "
+            << (openInterval.Contains(openInterval.LeftValue()) ||
+                openInterval.Contains(openInterval.RightValue()))
+            << std::endl;
+
+  const ignition::math::Intervald closedInterval =
+      ignition::math::Intervald::Closed(0., 1.);
+
+  // A closed interval should include its endpoints.
+  std::cout << "The " << closedInterval << " interval contains its endpoints: "
+            << (closedInterval.Contains(closedInterval.LeftValue()) ||
+                closedInterval.Contains(closedInterval.RightValue()))
+            << std::endl;
+
+  // Closed and open intervals may intersect.
+  std::cout << "Intervals " << closedInterval << " and " << openInterval
+            << " intersect: " << closedInterval.Intersects(openInterval)
+            << std::endl;
+
+  // The unbounded interval should include all non-empty intervals.
+  std::cout << "The " << ignition::math::Intervald::Unbounded
+            << " interval contains all previous non-empty intervals: "
+            << (ignition::math::Intervald::Unbounded.Contains(openInterval) ||
+                ignition::math::Intervald::Unbounded.Contains(closedInterval))
+            << std::endl;
+
+}
+//! [complete]

--- a/examples/piecewise_scalar_field3_example.cc
+++ b/examples/piecewise_scalar_field3_example.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+//! [complete]
+#include <iostream>
+
+#include <ignition/math/AdditivelySeparableScalarField3.hh>
+#include <ignition/math/PiecewiseScalarField3.hh>
+#include <ignition/math/Polynomial3.hh>
+
+int main(int argc, char **argv)
+{
+  const double k = 1.;
+  const ignition::math::Polynomial3d px(
+      ignition::math::Vector4d(0., 1., 0., 1.));
+  const ignition::math::Polynomial3d qy(
+      ignition::math::Vector4d(1., 0., 1., 0.));
+  const ignition::math::Polynomial3d rz(
+      ignition::math::Vector4d(1., 0., 0., -1.));
+  using AdditivelySeparableScalarField3dT =
+      ignition::math::AdditivelySeparableScalarField3d<
+        ignition::math::Polynomial3d>;
+  using PiecewiseScalarField3dT =
+      ignition::math::PiecewiseScalarField3d<
+        AdditivelySeparableScalarField3dT>;
+  const PiecewiseScalarField3dT P({
+      {ignition::math::Region3d(  // x < 0 halfspace
+          ignition::math::Intervald::Open(
+              -ignition::math::INF_D, 0.),
+          ignition::math::Intervald::Unbounded,
+          ignition::math::Intervald::Unbounded),
+       AdditivelySeparableScalarField3dT(k, px, qy, rz)},
+      {ignition::math::Region3d(  // x >= 0 halfspace
+          ignition::math::Intervald::LeftClosed(
+              0., ignition::math::INF_D),
+          ignition::math::Intervald::Unbounded,
+          ignition::math::Intervald::Unbounded),
+       AdditivelySeparableScalarField3dT(-k, px, qy, rz)}});
+
+  // A printable piecewise scalar field.
+  std::cout << "A piecewise scalar field in R^3 is made up of "
+            << "several pieces e.g. P(x, y, z) = " << P << std::endl;
+
+  // A piecewise scalar field can be evaluated.
+  std::cout << "Evaluating P(x, y, z) at (1, 0, 0) yields "
+            << P(ignition::math::Vector3d::UnitX)
+            << std::endl;
+  std::cout << "Evaluating P(x, y, z) at (-1, 0, 0) yields "
+            << P(-ignition::math::Vector3d::UnitX)
+            << std::endl;
+
+  // A piecewise scalar field can be queried for its minimum
+  // (provided the underlying scalar function allows it).
+  std::cout << "The global minimum of P(x, y, z) is "
+            << P.Minimum() << std::endl;
+}
+//! [complete]

--- a/examples/polynomial3_example.cc
+++ b/examples/polynomial3_example.cc
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+//! [complete]
+#include <iostream>
+#include <ignition/math/Polynomial3.hh>
+#include <ignition/math/Vector4.hh>
+
+int main(int argc, char **argv)
+{
+  // A default constructed polynomial should have zero coefficients.
+  std::cout << "A default constructed polynomial is always: "
+            << ignition::math::Polynomial3d() << std::endl;
+
+  // A constant polynomial only has an independent term.
+  std::cout << "A constant polynomial only has an independent term: "
+            << ignition::math::Polynomial3d::Constant(-1.) << std::endl;
+
+  // A cubic polynomial may be incomplete.
+  const ignition::math::Polynomial3d p(
+      ignition::math::Vector4d(1., 0., -1., 2.));
+  std::cout << "A cubic polynomial may be incomplete: " << p << std::endl;
+
+  // A polynomial can be evaluated.
+  const double x = 0.5;
+  std::cout << "Evaluating " << p << " at " << x
+            << " yields " << p(0.5) << std::endl;
+
+  // A polynomial can be queried for its minimum in a given interval,
+  // as well as for its global minimum (which may not always be finite).
+  const ignition::math::Intervald interval =
+      ignition::math::Intervald::Closed(-1, 1.);
+  std::cout << "The minimum of " << p << " in the " << interval
+            << " interval is " << p.Minimum(interval) << std::endl;
+  std::cout << "The global minimum of " << p
+            << " is " << p.Minimum() << std::endl;
+
+  const ignition::math::Polynomial3d q(
+      ignition::math::Vector4d(0., 1., 2., 1.));
+  std::cout << "The minimum of " << q << " in the " << interval
+            << " interval is " << q.Minimum(interval) << std::endl;
+  std::cout << "The global minimum of " << q
+            << " is " << q.Minimum() << std::endl;
+
+}
+//! [complete]

--- a/examples/region3_example.cc
+++ b/examples/region3_example.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+//! [complete]
+#include <iostream>
+#include <ignition/math/Region3.hh>
+#include <ignition/math/Vector3.hh>
+
+int main(int argc, char **argv)
+{
+  std::cout << std::boolalpha;
+
+  const ignition::math::Region3d defaultRegion;
+  // A default constructed region should be empty.
+  std::cout << "The " << defaultRegion << " region is empty: "
+            << defaultRegion.Empty() << std::endl;
+
+  const ignition::math::Region3d openRegion =
+      ignition::math::Region3d::Open(-1., -1., -1., 1., 1., 1.);
+  // An open region should exclude points on its boundary.
+  std::cout << "The " << openRegion << " region contains the "
+            << ignition::math::Vector3d::UnitX << " point: "
+            << openRegion.Contains(ignition::math::Vector3d::UnitX)
+            << std::endl;
+
+  const ignition::math::Region3d closedRegion =
+      ignition::math::Region3d::Closed(0., 0., 0., 1., 1., 1.);
+
+  // A closed region should include points on its boundary.
+  std::cout << "The " << closedRegion << " region contains the "
+            << ignition::math::Vector3d::UnitX << " point: "
+            << closedRegion.Contains(ignition::math::Vector3d::UnitX)
+            << std::endl;
+
+  // Closed and open regions may intersect.
+  std::cout << "Regions " << closedRegion << " and " << openRegion
+            << " intersect: " << closedRegion.Intersects(openRegion)
+            << std::endl;
+
+  // The unbounded region should include all non-empty regions.
+  std::cout << "The " << ignition::math::Region3d::Unbounded
+            << " region contains all previous non-empty intervals: "
+            << (ignition::math::Region3d::Unbounded.Contains(openRegion) ||
+                ignition::math::Region3d::Unbounded.Contains(closedRegion))
+            << std::endl;
+
+}
+//! [complete]

--- a/include/ignition/math/AdditivelySeparableScalarField3.hh
+++ b/include/ignition/math/AdditivelySeparableScalarField3.hh
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_MATH_SEPARABLE_SCALAR_FIELD3_HH_
+#define IGNITION_MATH_SEPARABLE_SCALAR_FIELD3_HH_
+
+#include <limits>
+#include <utility>
+
+#include <ignition/math/Region3.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/config.hh>
+
+namespace ignition
+{
+  namespace math
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_MATH_VERSION_NAMESPACE {
+    //
+    /** \class AdditivelySeparableScalarField3\
+     * AdditivelySeparableScalarField3.hh\
+     * ignition/math/AdditivelySeparableScalarField3.hh
+     */
+    /// \brief The AdditivelySeparableScalarField3 class constructs
+    /// a scalar field F in R^3 as a sum of scalar functions i.e.
+    /// F(x, y, z) = k (p(x) + q(y) + r(z)).
+    ///
+    /// ## Example
+    ///
+    /// \snippet examples/separable_scalar_field3_example.cc complete
+    template<typename ScalarFunctionT, typename ScalarT>
+    class AdditivelySeparableScalarField3
+    {
+      /// \brief Constructor
+      /// \param[in] _k scalar constant
+      /// \param[in] _p scalar function of x
+      /// \param[in] _q scalar function of y
+      /// \param[in] _r scalar function of z
+      public: AdditivelySeparableScalarField3(
+          ScalarT _k, ScalarFunctionT _p,
+          ScalarFunctionT _q, ScalarFunctionT _r)
+      : k(_k), p(std::move(_p)), q(std::move(_q)), r(std::move(_r))
+      {
+      }
+
+      /// \brief Evaluate the scalar field at `_point`
+      /// \param[in] _point scalar field argument
+      /// \return the result of evaluating `F(_point)`
+      public: ScalarT Evaluate(const Vector3<ScalarT> &_point) const
+      {
+        return this->k * (
+            this->p(_point.X()) +
+            this->q(_point.Y()) +
+            this->r(_point.Z()));
+      }
+
+      /// \brief Call operator overload
+      /// \see SeparableScalarField3::Evaluate()
+      public: ScalarT operator()(const Vector3<ScalarT> &_point) const
+      {
+        return this->Evaluate(_point);
+      }
+
+      /// \brief Compute scalar field minimum in a `_region`
+      /// \param[in] _region scalar field argument set to check
+      /// \return the scalar field minimum in the given interval,
+      ///   or NaN if the _region is empty
+      public: ScalarT Minimum(const Region3<ScalarT> &_region) const
+      {
+        if (_region.Empty())
+        {
+          return std::numeric_limits<ScalarT>::quiet_NaN();
+        }
+        return this->k * (
+            this->p.Minimum(_region.Ix()) +
+            this->q.Minimum(_region.Iy()) +
+            this->r.Minimum(_region.Iz()));
+      }
+
+      /// \brief Compute scalar field minimum
+      /// \return the scalar field minimum
+      public: ScalarT Minimum() const
+      {
+        return this->Minimum(Region3<ScalarT>::Unbounded);
+      }
+
+      /// \brief Stream insertion operator
+      /// \param _out output stream
+      /// \param _field SeparableScalarField3 to output
+      /// \return the stream
+      public: friend std::ostream &operator<<(
+          std::ostream &_out,
+          const ignition::math::AdditivelySeparableScalarField3<
+          ScalarFunctionT, ScalarT> &_field)
+      {
+        using std::abs;  // enable ADL
+        constexpr ScalarT epsilon =
+            std::numeric_limits<ScalarT>::epsilon();
+        if ((abs(_field.k) - ScalarT(1)) < epsilon)
+        {
+          if (_field.k < ScalarT(0))
+          {
+            _out << "-";
+          }
+        }
+        else
+        {
+          _out << _field.k << ".";
+        }
+        _out << "(";
+        _field.p.Print(_out, "x");
+        _out << " + ";
+        _field.q.Print(_out, "y");
+        _out << " + ";
+        _field.r.Print(_out, "z");
+        return _out << ")";
+      }
+
+      /// \brief Scalar constant
+      private: ScalarT k;
+
+      /// \brief Scalar function of x
+      private: ScalarFunctionT p;
+
+      /// \brief Scalar function of y
+      private: ScalarFunctionT q;
+
+      /// \brief Scalar function of z
+      private: ScalarFunctionT r;
+    };
+
+    template<typename ScalarFunctionT>
+    using AdditivelySeparableScalarField3f =
+        AdditivelySeparableScalarField3<ScalarFunctionT, float>;
+
+    template<typename ScalarFunctionT>
+    using AdditivelySeparableScalarField3d =
+        AdditivelySeparableScalarField3<ScalarFunctionT, double>;
+    }
+  }
+}
+#endif

--- a/include/ignition/math/AdditivelySeparableScalarField3.hh
+++ b/include/ignition/math/AdditivelySeparableScalarField3.hh
@@ -41,7 +41,7 @@ namespace ignition
     ///
     /// ## Example
     ///
-    /// \snippet examples/separable_scalar_field3_example.cc complete
+    /// \snippet examples/additively_separable_scalar_field3_example.cc complete
     template<typename ScalarFunctionT, typename ScalarT>
     class AdditivelySeparableScalarField3
     {

--- a/include/ignition/math/Interval.hh
+++ b/include/ignition/math/Interval.hh
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_MATH_INTERVAL_HH_
+#define IGNITION_MATH_INTERVAL_HH_
+
+#include <cmath>
+#include <limits>
+#include <ostream>
+#include <type_traits>
+#include <utility>
+
+#include <ignition/math/config.hh>
+
+namespace ignition
+{
+  namespace math
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_MATH_VERSION_NAMESPACE {
+    //
+    /// \class Interval Interval.hh ignition/math/Interval.hh
+    /// \brief The Interval class represents a range of real numbers.
+    /// Intervals may be open (a, b), left-closed [a, b), right-closed
+    /// (a, b], or fully closed [a, b].
+    ///
+    /// ## Example
+    ///
+    /// \snippet examples/interval_example.cc complete
+    template <typename T>
+    class Interval
+    {
+      /// \brief An unbounded interval (-∞, ∞)
+      public: static const Interval<T> &Unbounded;
+
+      /// \brief Constructor
+      public: Interval() = default;
+
+      /// \brief Constructor
+      /// \param[in] _leftValue leftmost interval value
+      /// \param[in] _leftClosed whether the interval is left-closed or not
+      /// \param[in] _rightValue rightmost interval value
+      /// \param[in] _rightClosed whether the interval is right-closed or not
+      public: Interval(T _leftValue, bool _leftClosed,
+                       T _rightValue, bool _rightClosed)
+      : leftValue(std::move(_leftValue)),
+        rightValue(std::move(_rightValue)),
+        leftClosed(_leftClosed),
+        rightClosed(_rightClosed)
+      {
+      }
+
+      /// \brief Make an open interval (`_leftValue`, `_rightValue`)
+      /// \param[in] _leftValue leftmost interval value
+      /// \param[in] _rightValue rightmost interval value
+      /// \return the open interval
+      public: static Interval<T> Open(T _leftValue, T _rightValue)
+      {
+        return Interval<T>(
+          std::move(_leftValue), false,
+          std::move(_rightValue), false);
+      }
+
+      /// \brief Make a left-closed interval [`_leftValue`, `_rightValue`)
+      /// \param[in] _leftValue leftmost interval value
+      /// \param[in] _rightValue rightmost interval value
+      /// \return the left-closed interval
+      public: static Interval<T> LeftClosed(T _leftValue, T _rightValue)
+      {
+        return Interval<T>(
+          std::move(_leftValue), true,
+          std::move(_rightValue), false);
+      }
+
+      /// \brief Make a right-closed interval (`_leftValue`, `_rightValue`]
+      /// \param[in] _leftValue leftmost interval value
+      /// \param[in] _rightValue rightmost interval value
+      /// \return the left-closed interval
+      public: static Interval<T> RightClosed(T _leftValue, T _rightValue)
+      {
+        return Interval<T>(
+          std::move(_leftValue), false,
+          std::move(_rightValue), true);
+      }
+
+      /// \brief Make a closed interval [`_leftValue`, `_rightValue`]
+      /// \param[in] _leftValue leftmost interval value
+      /// \param[in] _rightValue rightmost interval value
+      /// \return the closed interval
+      public: static Interval<T> Closed(T _leftValue, T _rightValue)
+      {
+        return Interval<T>{
+          std::move(_leftValue), true,
+          std::move(_rightValue), true};
+      }
+
+      /// \brief Get the leftmost interval value
+      /// \return the leftmost interval value
+      public: const T &LeftValue() const { return this->leftValue; }
+
+      /// \brief Check if the interval is left-closed
+      /// \return true if the interval is left-closed, false otherwise
+      public: bool IsLeftClosed() const { return this->leftClosed; }
+
+      /// \brief Get the rightmost interval value
+      /// \return the rightmost interval value
+      public: const T &RightValue() const { return this->rightValue; }
+
+      /// \brief Check if the interval is right-closed
+      /// \return true if the interval is right-closed, false otherwise
+      public: bool IsRightClosed() const { return this->rightClosed; }
+
+      /// \brief Check if the interval is empty
+      /// Some examples of empty intervals include
+      /// (a, a), [a, a), and [a + 1, a].
+      /// \return true if it is empty, false otherwise
+      public: bool Empty() const
+      {
+        if (this->leftClosed && this->rightClosed)
+        {
+          return this->rightValue < this->leftValue;
+        }
+        return this->rightValue <= this->leftValue;
+      }
+
+      /// \brief Check if the interval contains `_value`
+      /// \param[in] _value value to check for membership
+      /// \return true if it is contained, false otherwise
+      public: bool Contains(const T &_value) const
+      {
+        if (this->leftClosed && this->rightClosed)
+        {
+          return this->leftValue <= _value && _value <= this->rightValue;
+        }
+        if (this->leftClosed)
+        {
+          return this->leftValue <= _value && _value < this->rightValue;
+        }
+        if (this->rightClosed)
+        {
+          return this->leftValue < _value && _value <= this->rightValue;
+        }
+        return this->leftValue < _value && _value < this->rightValue;
+      }
+
+      /// \brief Check if the interval contains `_other` interval
+      /// \param[in] _other interval to check for membership
+      /// \return true if it is contained, false otherwise
+      public: bool Contains(const Interval<T> &_other) const
+      {
+        if (this->Empty() || _other.Empty())
+        {
+          return false;
+        }
+        if (!this->leftClosed && _other.leftClosed)
+        {
+          if (_other.leftValue <= this->leftValue)
+          {
+            return false;
+          }
+        }
+        else
+        {
+          if (_other.leftValue < this->leftValue)
+          {
+            return false;
+          }
+        }
+        if (!this->rightClosed && _other.rightClosed)
+        {
+          if (this->rightValue <= _other.rightValue)
+          {
+            return false;
+          }
+        }
+        else
+        {
+          if (this->rightValue < _other.rightValue)
+          {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      /// \brief Check if the interval intersects `_other` interval
+      /// \param[in] _other interval to check for intersection
+      /// \return true if both intervals intersect, false otherwise
+      public: bool Intersects(const Interval<T> &_other) const
+      {
+        if (this->Empty() || _other.Empty())
+        {
+          return false;
+        }
+        if (this->rightClosed && _other.leftClosed)
+        {
+          if (this->rightValue < _other.leftValue)
+          {
+            return false;
+          }
+        }
+        else
+        {
+          if (this->rightValue <= _other.leftValue)
+          {
+            return false;
+          }
+        }
+        if (_other.rightClosed && this->leftClosed)
+        {
+          if (_other.rightValue < this->leftValue)
+          {
+            return false;
+          }
+        }
+        else
+        {
+          if (_other.rightValue <= this->leftValue)
+          {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      /// \brief Equality test operator
+      /// \param _other interval to check for equality
+      /// \return true if intervals are equal, false otherwise
+      public: bool operator==(const Interval<T> &_other) const
+      {
+        return this->Contains(_other) && _other.Contains(*this);
+      }
+
+      /// \brief Inequality test operator
+      /// \param _other interval to check for inequality
+      /// \return true if intervals are unequal, false otherwise
+      public: bool operator!=(const Interval<T> &_other) const
+      {
+        return !this->Contains(_other) || !_other.Contains(*this);
+      }
+
+      /// \brief Stream insertion operator
+      /// \param _out output stream
+      /// \param _interval Interval to output
+      /// \return the stream
+      public: friend std::ostream &operator<<(
+        std::ostream &_out, const ignition::math::Interval<T> &_interval)
+      {
+        return _out << (_interval.leftClosed ? "[" : "(")
+                    << _interval.leftValue << ", " << _interval.rightValue
+                    << (_interval.rightClosed ? "]" : ")");
+      }
+
+      /// \brief The leftmost interval value
+      private: T leftValue{0};
+      /// \brief The righmost interval value
+      private: T rightValue{0};
+      /// \brief Whether the interval is left-closed or not
+      private: bool leftClosed{false};
+      /// \brief Whether the interval is right-closed or not
+      private: bool rightClosed{false};
+    };
+
+    namespace detail {
+       template<typename T>
+       const Interval<T> gUnboundedInterval =
+           Interval<T>::Open(-std::numeric_limits<T>::infinity(),
+                             std::numeric_limits<T>::infinity());
+    }  // namespace detail
+    template<typename T>
+    const Interval<T> &Interval<T>::Unbounded = detail::gUnboundedInterval<T>;
+
+    using Intervalf = Interval<float>;
+    using Intervald = Interval<double>;
+    }
+  }
+}
+
+#endif

--- a/include/ignition/math/PiecewiseScalarField3.hh
+++ b/include/ignition/math/PiecewiseScalarField3.hh
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_MATH_PIECEWISE_SCALAR_FIELD3_HH_
+#define IGNITION_MATH_PIECEWISE_SCALAR_FIELD3_HH_
+
+#include <algorithm>
+#include <iostream>
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include <ignition/math/Region3.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/config.hh>
+
+namespace ignition
+{
+  namespace math
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_MATH_VERSION_NAMESPACE {
+    //
+    /** \class PiecewiseScalarField3 PiecewiseScalarField3.hh\
+     * ignition/math/PiecewiseScalarField3.hh
+     */
+    /// \brief The PiecewiseScalarField3 class constructs a scalar field F
+    /// in R^3 as a union of scalar fields Pn, defined over regions Rn i.e.
+    /// piecewise.
+    ///
+    /// ## Example
+    ///
+    /// \snippet examples/piecewise_scalar_field3_example.cc complete
+    template<typename ScalarField3T, typename ScalarT>
+    class IGNITION_MATH_VISIBLE PiecewiseScalarField3
+    {
+      /// \brief A scalar field P in R^3 and
+      /// the region R in which it is defined
+      public: struct Piece {
+        Region3<ScalarT> region;
+        ScalarField3T field;
+      };
+
+      /// \brief Constructor
+      public: PiecewiseScalarField3() = default;
+
+      /// \brief Constructor
+      /// \param[in] _pieces scalar fields Pn and the regions Rn
+      ///   in which these are defined. Regions may not overlap.
+      public: explicit PiecewiseScalarField3(std::vector<Piece> _pieces)
+      : pieces(std::move(_pieces))
+      {
+        for (size_t i = 0; i < pieces.size(); ++i)
+        {
+          if (pieces[i].region.Empty())
+          {
+            std::cerr << "Region #" << i << "(" << pieces[i].region << ") "
+                      << "in piecewise scalar field definition is empty."
+                      << std::endl;
+          }
+          for (size_t j = i + 1; j < pieces.size(); ++j)
+          {
+            if (pieces[i].region.Intersects(pieces[j].region))
+            {
+              std::cerr << "Detected overlap between regions in "
+                        << "piecewise scalar field definition: "
+                        << "region #" << i << "(" << pieces[i].region
+                        << ") overlaps with region #" << j << " "
+                        << "(" << pieces[j].region << "). Region #"
+                        << i << " will take precedence when overlapping."
+                        << std::endl;
+            }
+          }
+        }
+      }
+
+      /// \brief Define piecewise scalar field as `_field` throughout R^3 space
+      public: static PiecewiseScalarField3 Throughout(ScalarField3T _field)
+      {
+        return PiecewiseScalarField3<ScalarField3T, ScalarT>({
+            {Region3<ScalarT>::Unbounded, std::move(_field)}});
+      }
+
+      /// \brief Evaluate the piecewise scalar field at `_point`
+      /// \param[in] _point piecewise scalar field argument
+      /// \return the result of evaluating `F(_point)`, or NaN
+      ///   if the scalar field is not defined at `_point`
+      public: ScalarT Evaluate(const Vector3<ScalarT> &_point) const
+      {
+        auto it = std::find_if(
+            this->pieces.begin(), this->pieces.end(),
+            [&](const Piece &piece) {
+              return piece.region.Contains(_point);
+            });
+        if (it == this->pieces.end())
+        {
+          return std::numeric_limits<ScalarT>::quiet_NaN();
+        }
+        return it->field(_point);
+      }
+
+      /// \brief Call operator overload
+      /// \see PiecewiseScalarField3::Evaluate()
+      public: ScalarT operator()(const Vector3<ScalarT> &_point) const
+      {
+        return this->Evaluate(_point);
+      }
+
+      /// \brief Compute the piecewise scalar field minimum
+      /// Note that, since this method computes the minimum
+      /// for each region independently, it implicitly assumes
+      /// continuity in the boundaries between regions, if any.
+      /// \return the scalar field minimum, or NaN if the
+      ///   scalar field is not defined anywhere (i.e. default
+      ///   constructed)
+      public: ScalarT Minimum() const
+      {
+        if (this->pieces.empty()) {
+          return std::numeric_limits<ScalarT>::quiet_NaN();
+        }
+        ScalarT minimum = std::numeric_limits<ScalarT>::infinity();
+        for (const Piece &piece : this->pieces)
+        {
+          if (!piece.region.Empty())
+          {
+            using std::min;
+            minimum = min(piece.field.Minimum(piece.region), minimum);
+          }
+        }
+        return minimum;
+      }
+
+      /// \brief Stream insertion operator
+      /// \param _out output stream
+      /// \param _field SeparableScalarField3 to output
+      /// \return the stream
+      public: friend std::ostream &operator<<(
+          std::ostream &_out,
+          const ignition::math::PiecewiseScalarField3<
+          ScalarField3T, ScalarT> &_field)
+      {
+        if (_field.pieces.empty())
+        {
+          return _out << "undefined";
+        }
+        for (size_t i = 0; i < _field.pieces.size() - 1; ++i)
+        {
+          _out << _field.pieces[i].field << " if (x, y, z) in "
+               << _field.pieces[i].region << "; ";
+        }
+        return _out << _field.pieces.back().field
+                    << " if (x, y, z) in "
+                    << _field.pieces.back().region;
+      }
+
+      /// \brief Scalar fields Pn and the regions Rn in which these are defined
+      private: std::vector<Piece> pieces;
+    };
+
+    template<typename ScalarField3T>
+    using PiecewiseScalarField3f = PiecewiseScalarField3<ScalarField3T, float>;
+    template<typename ScalarField3T>
+    using PiecewiseScalarField3d = PiecewiseScalarField3<ScalarField3T, double>;
+    }
+  }
+}
+
+#endif

--- a/include/ignition/math/Polynomial3.hh
+++ b/include/ignition/math/Polynomial3.hh
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_MATH_POLYNOMIAL3_HH_
+#define IGNITION_MATH_POLYNOMIAL3_HH_
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <utility>
+
+#include <ignition/math/Interval.hh>
+#include <ignition/math/Vector4.hh>
+#include <ignition/math/config.hh>
+
+namespace ignition
+{
+  namespace math
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_MATH_VERSION_NAMESPACE {
+    //
+    /// \class Polynomial3 Polynomial3.hh ignition/math/Polynomial3.hh
+    /// \brief The Polynomial3 class represents a cubic polynomial
+    /// with real coefficients p(x) = c0 x^3 + c1 x^2 + c2 x + c3.
+    /// ## Example
+    ///
+    /// \snippet examples/polynomial3_example.cc complete
+    template <typename T>
+    class IGNITION_MATH_VISIBLE Polynomial3
+    {
+      /// \brief Constructor
+      public: Polynomial3() = default;
+
+      /// \brief Constructor
+      /// \param[in] _coeffs coefficients c0 through c3, left to right
+      public: explicit Polynomial3(Vector4<T> _coeffs)
+      : coeffs(std::move(_coeffs))
+      {
+      }
+
+      /// \brief Make a constant polynomial
+      /// \return a p(x) = `_value` polynomial
+      public: static Polynomial3 Constant(T _value)
+      {
+        return Polynomial3(Vector4<T>(0., 0., 0., _value));
+      }
+
+      /// \brief Get the polynomial coefficients
+      /// \return this polynomial coefficients
+      public: const Vector4<T> &Coeffs() const { return this->coeffs; }
+
+      /// \brief Evaluate the polynomial at `_x`
+      /// For non-finite `_x`, this function
+      /// computes p(z) as z tends to `_x`.
+      /// \param[in] _x polynomial argument
+      /// \return the result of evaluating p(`_x`)
+      public: T Evaluate(const T &_x) const
+      {
+        using std::isfinite, std::abs, std::copysign;
+        if (!isfinite(_x))
+        {
+          const T epsilon =
+              std::numeric_limits<T>::epsilon();
+          if (abs(this->coeffs[0]) >= epsilon)
+          {
+            return _x * copysign(T(1.), this->coeffs[0]);
+          }
+          if (abs(this->coeffs[1]) >= epsilon)
+          {
+            return copysign(_x, this->coeffs[1]);
+          }
+          if (abs(this->coeffs[2]) >= epsilon)
+          {
+            return _x * copysign(T(1.), this->coeffs[2]);
+          }
+          return this->coeffs[3];
+        }
+        const T _x2 = _x * _x;
+        const T _x3 = _x2 * _x;
+
+        return (this->coeffs[0] * _x3 + this->coeffs[1] * _x2 +
+                this->coeffs[2] * _x + this->coeffs[3]);
+      }
+
+      /// \brief Call operator overload
+      /// \see Polynomial3::Evaluate()
+      public: T operator()(const T &_x) const
+      {
+        return this->Evaluate(_x);
+      }
+
+      /// \brief Compute polynomial minimum in an `_interval`
+      /// \param[in] _interval polynomial argument interval to check
+      /// \return the polynomial minimum in the given interval,
+      ///   or NaN if the interval is empty
+      public: T Minimum(const Interval<T> &_interval) const
+      {
+        if (_interval.Empty())
+        {
+          return std::numeric_limits<T>::quiet_NaN();
+        }
+        using std::min, std::abs, std::sqrt;  // enable ADL
+        constexpr T epsilon = std::numeric_limits<T>::epsilon();
+        // For open intervals, assume continuity in the limit
+        T minimum = min(this->Evaluate(_interval.LeftValue()),
+                        this->Evaluate(_interval.RightValue()));
+        if (abs(this->coeffs[0]) >= epsilon)
+        {
+          // cubic poylnomial
+          const T a = this->coeffs[0] * T(3.);
+          const T b = this->coeffs[1] * T(2.);
+          const T c = this->coeffs[2];
+
+          const T discriminant = b * b - T(4.) * a * c;
+          if (discriminant >= T(0.))
+          {
+            const T x0 = (-b + sqrt(discriminant)) / T(2.) * a;
+            if ((T(2.) * a * x0 + b) > T(0.) && _interval.Contains(x0))
+            {
+              minimum = min(this->Evaluate(x0), minimum);
+            }
+            const T x1 = (-b - sqrt(discriminant)) / T(2.) * a;
+            if ((T(2.) * a * x1 + b) > T(0.) && _interval.Contains(x1))
+            {
+              minimum = min(this->Evaluate(x1), minimum);
+            }
+          }
+        }
+        else if (abs(this->coeffs[1]) >= epsilon)
+        {
+          // quadratic polynomial
+          const T b = this->coeffs[1] * T(2.);
+          const T c = this->coeffs[2];
+          if (b > T(0.))
+          {
+            const T x = -c / b;
+            if (_interval.Contains(x))
+            {
+              minimum = min(this->Evaluate(x), minimum);
+            }
+          }
+        }
+        return minimum;
+      }
+
+      /// \brief Compute polynomial minimum
+      /// \return the polynomial minimum (may not be finite)
+      public: T Minimum() const
+      {
+        return this->Minimum(Interval<T>::Unbounded);
+      }
+
+      /// \brief Prints polynomial as p(`_x`) to `_out` stream
+      /// \param[in] _out Output stream to print to
+      /// \param[in] _x Argument name to be used
+      public: void Print(std::ostream &_out, const std::string &_x = "x") const
+      {
+        constexpr T epsilon =
+            std::numeric_limits<T>::epsilon();
+        bool streamStarted = false;
+        for (size_t i = 0; i < 4; ++i)
+        {
+          using std::abs;  // enable ADL
+          const T magnitude = abs(this->coeffs[i]);
+          const bool sign = this->coeffs[i] < T(0);
+          const int exponent = 3 - i;
+          if (magnitude >= epsilon)
+          {
+            if (streamStarted)
+            {
+              if (sign)
+              {
+                _out << " - ";
+              }
+              else
+              {
+                _out << " + ";
+              }
+            }
+            else if (sign)
+            {
+              _out << "-";
+            }
+            if (exponent > 0)
+            {
+              if ((magnitude - T(1)) > epsilon)
+              {
+                _out << magnitude << " ";
+              }
+              _out <<  _x;
+              if (exponent > 1)
+              {
+                _out << "^" << exponent;
+              }
+            }
+            else
+            {
+              _out << magnitude;
+            }
+            streamStarted = true;
+          }
+        }
+        if (!streamStarted)
+        {
+          _out << this->coeffs[3];
+        }
+      }
+
+      /// \brief Stream insertion operator
+      /// \param _out output stream
+      /// \param _p Polynomial3 to output
+      /// \return the stream
+      public: friend std::ostream &operator<<(
+        std::ostream &_out, const ignition::math::Polynomial3<T> &_p)
+      {
+        _p.Print(_out, "x");
+        return _out;
+      }
+
+      /// \brief Polynomial coefficients
+      private: Vector4<T> coeffs;
+    };
+    using Polynomial3f = Polynomial3<float>;
+    using Polynomial3d = Polynomial3<double>;
+    }
+  }
+}
+
+#endif

--- a/include/ignition/math/Region3.hh
+++ b/include/ignition/math/Region3.hh
@@ -148,7 +148,7 @@ namespace ignition
       }
 
       /// \brief Check if the region intersects `_other` region
-      /// \param[in] _region region to check for intersection
+      /// \param[in] _other region to check for intersection
       /// \return true if it is contained, false otherwise
       public: bool Intersects(const Region3<T>& _other) const
       {

--- a/include/ignition/math/Region3.hh
+++ b/include/ignition/math/Region3.hh
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_MATH_REGION3_HH_
+#define IGNITION_MATH_REGION3_HH_
+
+#include <cmath>
+#include <ostream>
+#include <utility>
+
+#include <ignition/math/Interval.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/config.hh>
+
+namespace ignition
+{
+  namespace math
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_MATH_VERSION_NAMESPACE {
+    //
+    /// \class Region3 Region3.hh ignition/math/Region3.hh
+    /// \brief The Region3 class represents the cartesian product
+    /// of intervals Ix ✕ Iy ✕ Iz, one per axis, yielding an
+    /// axis-aligned region of R^3 space. It can be thought as
+    /// an intersection of halfspaces. Regions may be be open or
+    /// closed in their boundaries, if any.
+    ///
+    /// ## Example
+    ///
+    /// \snippet examples/region3_example.cc complete
+    template <typename T>
+    class IGNITION_MATH_VISIBLE Region3
+    {
+      /// \brief An unbounded region (-∞, ∞) ✕ (-∞, ∞) ✕ (-∞, ∞)
+      public: static const Region3<T> &Unbounded;
+
+      /// \brief Constructor
+      public: Region3() = default;
+
+      /// \brief Constructor
+      /// \param[in] _ix x-axis interval
+      /// \param[in] _iy y-axis interval
+      /// \param[in] _iz z-axis interval
+      public: Region3(Interval<T> _ix, Interval<T> _iy, Interval<T> _iz)
+      : ix(std::move(_ix)), iy(std::move(_iy)), iz(std::move(_iz))
+      {
+      }
+
+      /// \brief Make an open region
+      /// \param[in] _xLeft leftmost x-axis interval value
+      /// \param[in] _xRight righmost x-axis interval value
+      /// \param[in] _yLeft leftmost y-axis interval value
+      /// \param[in] _yRight righmost y-axis interval value
+      /// \param[in] _zLeft leftmost z-axis interval value
+      /// \param[in] _zRight righmost z-axis interval value
+      /// \return the (`_xLeft`, `_xRight`) ✕ (`_yLeft`, `_yRight`)
+      ///  ✕ (`_zLeft`, `_zRight`) open region
+      public: static Region3<T> Open(
+          T _xLeft, T _yLeft, T _zLeft,
+          T _xRight, T _yRight, T _zRight)
+      {
+        return Region3<T>(Interval<T>::Open(_xLeft, _xRight),
+                          Interval<T>::Open(_yLeft, _yRight),
+                          Interval<T>::Open(_zLeft, _zRight));
+      }
+
+      /// \brief Make an closed region
+      /// \param[in] _xLeft leftmost x-axis interval value
+      /// \param[in] _xRight righmost x-axis interval value
+      /// \param[in] _yLeft leftmost y-axis interval value
+      /// \param[in] _yRight righmost y-axis interval value
+      /// \param[in] _zLeft leftmost z-axis interval value
+      /// \param[in] _zRight righmost z-axis interval value
+      /// \return the [`_xLeft`, `_xRight`] ✕ [`_yLeft`, `_yRight`]
+      ///  ✕ [`_zLeft`, `_zRight`] closed region
+      public: static Region3<T> Closed(
+          T _xLeft, T _yLeft, T _zLeft,
+          T _xRight, T _yRight, T _zRight)
+      {
+        return Region3<T>(Interval<T>::Closed(_xLeft, _xRight),
+                          Interval<T>::Closed(_yLeft, _yRight),
+                          Interval<T>::Closed(_zLeft, _zRight));
+      }
+
+      /// \brief Get the x-axis interval for the region
+      /// \return the x-axis interval
+      public: const Interval<T> &Ix() const { return this->ix; }
+
+      /// \brief Get the y-axis interval for the region
+      /// \return the y-axis interval
+      public: const Interval<T> &Iy() const { return this->iy; }
+
+      /// \brief Get the z-axis interval for the region
+      /// \return the z-axis interval
+      public: const Interval<T> &Iz() const { return this->iz; }
+
+      /// \brief Check if the region is empty
+      /// A region is empty if any of the intervals
+      /// it is defined with (i.e. Ix, Iy, Iz) are.
+      /// \return true if it is empty, false otherwise
+      public: bool Empty() const
+      {
+        return this->ix.Empty() || this->iy.Empty() || this->iz.Empty();
+      }
+
+      /// \brief Stream insertion operator
+      /// \param _out output stream
+      /// \param _pt Interval to output
+      /// \return the stream
+      public: friend std::ostream &operator<<(
+        std::ostream &_out, const ignition::math::Region3<T> &_r)
+      {
+        return _out <<_r.ix << " x " << _r.iy << " x " << _r.iz;
+      }
+
+      /// \brief Check if the region contains `_point`
+      /// \param[in] _point point to check for membership
+      /// \return true if it is contained, false otherwise
+      public: bool Contains(const Vector3<T> &_point) const
+      {
+        return (this->ix.Contains(_point.X()) &&
+                this->iy.Contains(_point.Y()) &&
+                this->iz.Contains(_point.Z()));
+      }
+
+      /// \brief Check if the region contains `_other` region
+      /// \param[in] _other region to check for membership
+      /// \return true if it is contained, false otherwise
+      public: bool Contains(const Region3<T> &_other) const
+      {
+        return (this->ix.Contains(_other.ix) &&
+                this->iy.Contains(_other.iy) &&
+                this->iz.Contains(_other.iz));
+      }
+
+      /// \brief Check if the region intersects `_other` region
+      /// \param[in] _region region to check for intersection
+      /// \return true if it is contained, false otherwise
+      public: bool Intersects(const Region3<T>& _other) const
+      {
+        return (this->ix.Intersects(_other.ix) &&
+                this->iy.Intersects(_other.iy) &&
+                this->iz.Intersects(_other.iz));
+      }
+
+      /// \brief The x-axis interval
+      private: Interval<T> ix;
+      /// \brief The y-axis interval
+      private: Interval<T> iy;
+      /// \brief The z-axis interval
+      private: Interval<T> iz;
+    };
+
+    namespace detail {
+       template<typename T>
+       const Region3<T> gUnboundedRegion3(
+           Interval<T>::Unbounded,
+           Interval<T>::Unbounded,
+           Interval<T>::Unbounded);
+    }
+    template<typename T>
+    const Region3<T> &Region3<T>::Unbounded = detail::gUnboundedRegion3<T>;
+
+    using Region3f = Region3<float>;
+    using Region3d = Region3<double>;
+    }
+  }
+}
+
+#endif

--- a/src/AdditivelySeparableScalarField3_TEST.cc
+++ b/src/AdditivelySeparableScalarField3_TEST.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gtest/gtest.h>
+
+#include "ignition/math/AdditivelySeparableScalarField3.hh"
+#include "ignition/math/Polynomial3.hh"
+
+using namespace ignition;
+
+/////////////////////////////////////////////////
+TEST(AdditivelySeparableScalarField3Test, Evaluate)
+{
+  using ScalarFunctionT = std::function<double(double)>;
+  using AdditivelySeparableScalarField3dT =
+      math::AdditivelySeparableScalarField3d<ScalarFunctionT>;
+  const double k = 1.;
+  auto f = [](double x) { return x; };
+  const AdditivelySeparableScalarField3dT F(k, f, f, f);
+  EXPECT_DOUBLE_EQ(F(math::Vector3d::Zero), 0.);
+  EXPECT_DOUBLE_EQ(F(math::Vector3d::One), 3.);
+  EXPECT_DOUBLE_EQ(F(math::Vector3d::UnitX), 1.);
+  EXPECT_DOUBLE_EQ(F(math::Vector3d::UnitY), 1.);
+  EXPECT_DOUBLE_EQ(F(math::Vector3d::UnitZ), 1.);
+  const math::Vector3d INF_V(
+      math::INF_D, math::INF_D, math::INF_D);
+  EXPECT_DOUBLE_EQ(F(INF_V), math::INF_D);
+}
+
+/////////////////////////////////////////////////
+TEST(AdditivelySeparableScalarField3Test, Minimum)
+{
+  using AdditivelySeparableScalarField3dT =
+      math::AdditivelySeparableScalarField3d<math::Polynomial3d>;
+  const double k = 1.;
+  const math::Polynomial3d p(math::Vector4d(0., 1., 1., 2.25));
+  const AdditivelySeparableScalarField3dT F(k, p, p, p);
+  EXPECT_DOUBLE_EQ(F.Minimum(), 6.);
+  const math::Region3d region =
+      math::Region3d::Open(0., 0., 0., 1., 1., 1.);
+  EXPECT_DOUBLE_EQ(F.Minimum(region), 6.75);
+}

--- a/src/Interval_TEST.cc
+++ b/src/Interval_TEST.cc
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gtest/gtest.h>
+
+#include "ignition/math/Interval.hh"
+
+using namespace ignition;
+
+/////////////////////////////////////////////////
+TEST(IntervalTest, DefaultConstructor)
+{
+  const math::Intervald interval;
+  EXPECT_DOUBLE_EQ(
+      interval.LeftValue(),
+      interval.RightValue());
+}
+
+/////////////////////////////////////////////////
+TEST(IntervalTest, Constructor)
+{
+  constexpr bool kClosed = true;
+
+  const math::Intervald interval(
+      0., kClosed, 1., !kClosed);
+  EXPECT_DOUBLE_EQ(interval.LeftValue(), 0.);
+  EXPECT_TRUE(interval.IsLeftClosed());
+  EXPECT_DOUBLE_EQ(interval.RightValue(), 1.);
+  EXPECT_FALSE(interval.IsRightClosed());
+}
+
+/////////////////////////////////////////////////
+TEST(IntervalTest, ConstructionHelpers)
+{
+  const math::Intervald openInterval =
+      math::Intervald::Open(0., 1.);
+  EXPECT_DOUBLE_EQ(openInterval.LeftValue(), 0.);
+  EXPECT_FALSE(openInterval.IsLeftClosed());
+  EXPECT_DOUBLE_EQ(openInterval.RightValue(), 1.);
+  EXPECT_FALSE(openInterval.IsRightClosed());
+  const math::Intervald closedInterval =
+      math::Intervald::Closed(0., 1.);
+  EXPECT_DOUBLE_EQ(closedInterval.LeftValue(), 0.);
+  EXPECT_TRUE(closedInterval.IsLeftClosed());
+  EXPECT_DOUBLE_EQ(closedInterval.RightValue(), 1.);
+  EXPECT_TRUE(closedInterval.IsRightClosed());
+}
+
+/////////////////////////////////////////////////
+TEST(IntervalTest, EmptyCheck)
+{
+  EXPECT_FALSE(math::Intervald::Open(0., 1.).Empty());
+  EXPECT_TRUE(math::Intervald::Open(0., 0.).Empty());
+  EXPECT_FALSE(math::Intervald::Closed(0., 0.).Empty());
+  EXPECT_TRUE(math::Intervald::Closed(1., 0.).Empty());
+}
+
+/////////////////////////////////////////////////
+TEST(IntervalTest, MembershipCheck)
+{
+  const math::Intervald openInterval =
+      math::Intervald::Open(0., 1.);
+  EXPECT_FALSE(openInterval.Contains(0.));
+  EXPECT_TRUE(openInterval.Contains(0.5));
+  EXPECT_FALSE(openInterval.Contains(1));
+
+  EXPECT_TRUE(openInterval.Contains(openInterval));
+
+  const math::Intervald closedInterval =
+      math::Intervald::Closed(0., 1.);
+  EXPECT_TRUE(closedInterval.Contains(0.));
+  EXPECT_TRUE(closedInterval.Contains(0.5));
+  EXPECT_TRUE(closedInterval.Contains(1));
+
+  EXPECT_TRUE(closedInterval.Contains(closedInterval));
+  EXPECT_FALSE(openInterval.Contains(closedInterval));
+  EXPECT_TRUE(closedInterval.Contains(openInterval));
+
+  const math::Intervald emptyInterval =
+      math::Intervald::Open(0., 0.);
+  EXPECT_FALSE(emptyInterval.Contains(0.));
+
+  const math::Intervald degenerateInterval =
+      math::Intervald::Closed(0., 0.);
+  EXPECT_TRUE(degenerateInterval.Contains(0.));
+
+  EXPECT_FALSE(closedInterval.Contains(emptyInterval));
+  EXPECT_TRUE(closedInterval.Contains(degenerateInterval));
+}
+
+/////////////////////////////////////////////////
+TEST(IntervalTest, IntersectionCheck)
+{
+  const math::Intervald interval =
+      math::Intervald::Open(0., 1.);
+  EXPECT_TRUE(interval.Intersects(math::Intervald::Open(0.5, 1.5)));
+  EXPECT_TRUE(interval.Intersects(math::Intervald::Open(-0.5, 0.5)));
+  EXPECT_FALSE(interval.Intersects(math::Intervald::Open(1., 2.)));
+  EXPECT_FALSE(interval.Intersects(math::Intervald::Open(-1., 0.)));
+  EXPECT_FALSE(interval.Intersects(math::Intervald::Open(0.5, 0.5)));
+}
+
+/////////////////////////////////////////////////
+TEST(IntervalTest, Unbounded)
+{
+  EXPECT_FALSE(math::Intervald::Unbounded.Empty());
+  EXPECT_FALSE(math::Intervald::Unbounded.IsLeftClosed());
+  EXPECT_FALSE(math::Intervald::Unbounded.IsRightClosed());
+}

--- a/src/PiecewiseScalarField3_TEST.cc
+++ b/src/PiecewiseScalarField3_TEST.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gtest/gtest.h>
+
+#include "ignition/math/AdditivelySeparableScalarField3.hh"
+#include "ignition/math/PiecewiseScalarField3.hh"
+#include "ignition/math/Polynomial3.hh"
+
+using namespace ignition;
+
+/////////////////////////////////////////////////
+TEST(PiecewiseScalarField3Test, Evaluate)
+{
+  using ScalarField3dT = std::function<double(const math::Vector3d&)>;
+  using PiecewiseScalarField3dT = math::PiecewiseScalarField3d<ScalarField3dT>;
+  {
+    const PiecewiseScalarField3dT F;
+    EXPECT_TRUE(std::isnan(F(math::Vector3d::Zero)));
+  }
+  {
+    const PiecewiseScalarField3dT F =
+        PiecewiseScalarField3dT::Throughout(
+            [](const math::Vector3d& v) { return v.X(); });
+    EXPECT_DOUBLE_EQ(F(math::Vector3d::Zero), 0.);
+    EXPECT_DOUBLE_EQ(F(math::Vector3d(0.5, 0.5, 0.5)), 0.5);
+    EXPECT_DOUBLE_EQ(F(math::Vector3d::One), 1.);
+    EXPECT_DOUBLE_EQ(F(math::Vector3d::UnitX), 1.);
+  }
+  {
+    const math::Region3d region0 =
+        math::Region3d::Open(0., 0., 0., 1., 1., 1.);
+    auto field0 = [](const math::Vector3d& v) { return v.X(); };
+    const math::Region3d region1 =
+        math::Region3d::Open(-1., -1., -1., 0., 0., 0.);
+    auto field1 = [](const math::Vector3d& v) { return v.Y(); };
+    const PiecewiseScalarField3dT F({
+        {region0, field0}, {region1, field1}});
+    EXPECT_DOUBLE_EQ(F(math::Vector3d(0.5, 0.25, 0.5)), 0.5);
+    EXPECT_DOUBLE_EQ(F(math::Vector3d(-0.5, -0.25, -0.5)), -0.25);
+    EXPECT_TRUE(std::isnan(F(math::Vector3d(0.5, -0.25, 0.5))));
+    EXPECT_TRUE(std::isnan(F(math::Vector3d(-0.5, 0.25, -0.5))));
+  }
+}
+
+/////////////////////////////////////////////////
+TEST(PiecewiseScalarField3Test, Minimum)
+{
+  using AdditivelySeparableScalarField3dT =
+      math::AdditivelySeparableScalarField3d<math::Polynomial3d>;
+  using PiecewiseScalarField3dT =
+      math::PiecewiseScalarField3d<AdditivelySeparableScalarField3dT>;
+  {
+    const PiecewiseScalarField3dT F =
+        PiecewiseScalarField3dT::Throughout(
+            AdditivelySeparableScalarField3dT(
+                1.,
+                math::Polynomial3d::Constant(0.),
+                math::Polynomial3d::Constant(1.),
+                math::Polynomial3d::Constant(0.)));
+    EXPECT_DOUBLE_EQ(F.Minimum(), 1.);
+  }
+  {
+    const math::Region3d region0 =
+        math::Region3d::Open(0., 0., 0., 1., 1., 1.);
+    const AdditivelySeparableScalarField3dT field0(
+        1.,
+        math::Polynomial3d(
+            math::Vector4d(0., 1., 0., 0.)),
+        math::Polynomial3d::Constant(0.),
+        math::Polynomial3d::Constant(0.));
+    const math::Region3d region1 =
+        math::Region3d::Open(-1., -1., -1., 0., 0., 0.);
+    const AdditivelySeparableScalarField3dT field1(
+        1.,
+        math::Polynomial3d::Constant(0.),
+        math::Polynomial3d(
+            math::Vector4d(0., 1., 0., 1.)),
+        math::Polynomial3d::Constant(0.));
+    const PiecewiseScalarField3dT F({
+        {region0, field0}, {region1, field1}});
+    EXPECT_DOUBLE_EQ(F.Minimum(), 0.);
+  }
+}

--- a/src/Polynomial3_TEST.cc
+++ b/src/Polynomial3_TEST.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gtest/gtest.h>
+
+#include "ignition/math/Polynomial3.hh"
+
+using namespace ignition;
+
+/////////////////////////////////////////////////
+TEST(Polynomial3Test, DefaultConstructor)
+{
+  const math::Polynomial3d poly;
+  EXPECT_EQ(poly.Coeffs(), math::Vector4d::Zero);
+}
+
+/////////////////////////////////////////////////
+TEST(Polynomial3Test, Constructor)
+{
+  const math::Polynomial3d poly(math::Vector4d::One);
+  EXPECT_EQ(poly.Coeffs(), math::Vector4d::One);
+}
+
+/////////////////////////////////////////////////
+TEST(Polynomial3Test, ConstructionHelpers)
+{
+  const math::Polynomial3d poly = math::Polynomial3d::Constant(1.);
+  EXPECT_EQ(poly.Coeffs(), math::Vector4d(0., 0., 0., 1.));
+}
+
+/////////////////////////////////////////////////
+TEST(Polynomial3Test, Evaluate)
+{
+  {
+    const math::Polynomial3d p =
+        math::Polynomial3d::Constant(1.);
+    EXPECT_DOUBLE_EQ(p(-1.), 1.);
+    EXPECT_DOUBLE_EQ(p(0.), 1.);
+    EXPECT_DOUBLE_EQ(p(1.), 1.);
+    EXPECT_DOUBLE_EQ(p(math::INF_D), 1.);
+  }
+  {
+    const math::Polynomial3d p(math::Vector4d::One);
+    EXPECT_DOUBLE_EQ(p(-1.), 0.);
+    EXPECT_DOUBLE_EQ(p(0.), 1.);
+    EXPECT_DOUBLE_EQ(p(1.), 4.);
+    EXPECT_DOUBLE_EQ(p(-math::INF_D), -math::INF_D);
+  }
+}
+
+/////////////////////////////////////////////////
+TEST(Polynomial3Test, Minimum)
+{
+  {
+    const math::Polynomial3d p0 =
+        math::Polynomial3d::Constant(1.);
+    EXPECT_DOUBLE_EQ(p0.Minimum(), 1.);
+  }
+  {
+    const math::Polynomial3d p1(
+        math::Vector4d(0., 0., 1., 1.));
+    EXPECT_DOUBLE_EQ(p1.Minimum(), -math::INF_D);
+    EXPECT_DOUBLE_EQ(p1.Minimum(
+        math::Intervald::Open(0., 1.)), 1.);
+  }
+  {
+    const math::Polynomial3d p2(
+        math::Vector4d(0., 1., 1., 1.));
+    EXPECT_DOUBLE_EQ(p2.Minimum(), 0.75);
+    EXPECT_DOUBLE_EQ(p2.Minimum(
+        math::Intervald::Open(1., 2.)), 3.);
+  }
+  {
+    const math::Polynomial3d p3(
+        math::Vector4d(1., 1., 1., 1.));
+    EXPECT_DOUBLE_EQ(p3.Minimum(), -math::INF_D);
+    EXPECT_DOUBLE_EQ(p3.Minimum(
+        math::Intervald::Open(-1., 1.)), 0.);
+  }
+}

--- a/src/Region3_TEST.cc
+++ b/src/Region3_TEST.cc
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gtest/gtest.h>
+
+#include "ignition/math/Region3.hh"
+
+using namespace ignition;
+
+/////////////////////////////////////////////////
+TEST(Region3Test, DefaultConstructor)
+{
+  const math::Region3d region;
+  EXPECT_TRUE(region.Ix().Empty());
+  EXPECT_TRUE(region.Iy().Empty());
+  EXPECT_TRUE(region.Iz().Empty());
+}
+
+/////////////////////////////////////////////////
+TEST(Region3Test, Constructor)
+{
+  const math::Region3d region(
+      math::Intervald::Open(0., 1.),
+      math::Intervald::Closed(-1., 1.),
+      math::Intervald::Open(-1., 0.));
+  EXPECT_EQ(region.Ix(), math::Intervald::Open(0., 1.));
+  EXPECT_EQ(region.Iy(), math::Intervald::Closed(-1., 1.));
+  EXPECT_EQ(region.Iz(), math::Intervald::Open(-1., 0.));
+}
+
+/////////////////////////////////////////////////
+TEST(Region3Test, ConstructionHelpers)
+{
+  const math::Region3d openRegion =
+      math::Region3d::Open(0., 0., 0., 1., 1., 1.);
+  EXPECT_EQ(openRegion.Ix(), math::Intervald::Open(0., 1.));
+  EXPECT_EQ(openRegion.Iy(), math::Intervald::Open(0., 1.));
+  EXPECT_EQ(openRegion.Iz(), math::Intervald::Open(0., 1.));
+  const math::Region3d closedRegion =
+      math::Region3d::Closed(0., 0., 0., 1., 1., 1.);
+  EXPECT_EQ(closedRegion.Ix(), math::Intervald::Closed(0., 1.));
+  EXPECT_EQ(closedRegion.Iy(), math::Intervald::Closed(0., 1.));
+  EXPECT_EQ(closedRegion.Iz(), math::Intervald::Closed(0., 1.));
+}
+
+/////////////////////////////////////////////////
+TEST(Region3Test, EmptyCheck)
+{
+  EXPECT_FALSE(math::Region3d::Open(0., 0., 0., 1., 1., 1.).Empty());
+  EXPECT_TRUE(math::Region3d::Open(0., 0., 0., 0., 0., 0.).Empty());
+  EXPECT_TRUE(math::Region3d::Open(0., 0., 0., 0., 1., 1.).Empty());
+  EXPECT_TRUE(math::Region3d::Open(0., 0., 0., 1., 0., 1.).Empty());
+  EXPECT_TRUE(math::Region3d::Open(0., 0., 0., 1., 1., 0.).Empty());
+  EXPECT_FALSE(math::Region3d::Closed(0., 0., 0., 0., 0., 0.).Empty());
+  EXPECT_TRUE(math::Region3d::Closed(1., 1., 1., 0., 0., 0.).Empty());
+}
+
+/////////////////////////////////////////////////
+TEST(Region3Test, MembershipCheck)
+{
+  const math::Region3d openRegion =
+      math::Region3d::Open(0., 0., 0., 1., 1., 1.);
+  EXPECT_FALSE(openRegion.Contains(math::Vector3d(0., 0., 0.)));
+  EXPECT_TRUE(openRegion.Contains(math::Vector3d(0.5, 0.5, 0.5)));
+  EXPECT_FALSE(openRegion.Contains(math::Vector3d(1., 1., 1.)));
+
+  const math::Region3d closedRegion =
+      math::Region3d::Closed(0., 0., 0., 1., 1., 1.);
+  EXPECT_TRUE(closedRegion.Contains(math::Vector3d(0., 0., 0.)));
+  EXPECT_TRUE(closedRegion.Contains(math::Vector3d(0.5, 0.5, 0.5)));
+  EXPECT_TRUE(closedRegion.Contains(math::Vector3d(1., 1., 1.)));
+
+  EXPECT_TRUE(closedRegion.Contains(openRegion));
+  EXPECT_FALSE(openRegion.Contains(closedRegion));
+}
+
+/////////////////////////////////////////////////
+TEST(Region3Test, IntersectionCheck)
+{
+  const math::Region3d region =
+      math::Region3d::Open(0., 0., 0., 1., 1., 1.);
+  EXPECT_TRUE(region.Intersects(
+      math::Region3d::Open(0.5, 0.5, 0.5, 1.5, 1.5, 1.5)));
+  EXPECT_TRUE(region.Intersects(
+      math::Region3d::Open(-0.5, -0.5, -0.5, 0.5, 0.5, 0.5)));
+  EXPECT_FALSE(region.Intersects(
+      math::Region3d::Open(1., 1., 1., 2., 2., 2.)));
+  EXPECT_FALSE(region.Intersects(
+      math::Region3d::Open(-1., -1., -1., 0., 0., 0.)));
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary
Spin-off from https://github.com/ignitionrobotics/ign-gazebo/pull/1357. This PR introduces a number of classes, namely:

- an Interval class for scalar intervals
- a Polynomial3 class for cubic polynomials
- a Region3 class for regions in R^3
- a SeparableScalarField3 class for separable scalar fields in R^3
- a PiecewiseScalarField3 class for piecewise scalar fields in R^3

to support polynomial piecewise scalar fields.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.