### PR TITLE
Added helper function to check if a string represents a time

### DIFF
--- a/include/ignition/math/Helpers.hh
+++ b/include/ignition/math/Helpers.hh
@@ -895,7 +895,7 @@ namespace ignition
 
     /// \brief Check if the given string represents a time.
     /// An example time string is "0 00:00:00.000", which has the format
-    /// "DAYS HOURS:MINUTES:SECONDS.NANOSECONDS"
+    /// "DAYS HOURS:MINUTES:SECONDS.MILLISECONDS"
     /// \return True if the regex was able to split the string otherwise False
     inline bool isTimeString(const std::string &_timeString)
     {

--- a/include/ignition/math/Helpers.hh
+++ b/include/ignition/math/Helpers.hh
@@ -893,6 +893,50 @@ namespace ignition
                                                 // .000 - 0.999
 
 
+    /// \brief Check if the given string represents a time.
+    /// An example time string is "0 00:00:00.000", which has the format
+    /// "DAYS HOURS:MINUTES:SECONDS.NANOSECONDS"
+    /// \return True if the regex was able to split the string otherwise False
+    inline bool isTimeString(const std::string &_timeString)
+    {
+      std::smatch matches;
+
+      // `matches` should always be a size of 6 as there are 6 matching
+      // groups in the regex.
+      // 1. The whole regex
+      // 2. The days
+      // 3. The hours
+      // 4. The minutes
+      // 5. The seconds
+      // 6. The milliseconds
+      // Note that the space will remain in the day match, the colon
+      // will remain in the hour and minute matches, and the period will
+      // remain in the millisecond match
+      if (!std::regex_search(_timeString, matches, time_regex) ||
+          matches.size() != 6)
+        return false;
+
+      std::string dayString = matches[1];
+
+      // Days are the only unbounded number, so check first to see if stoi
+      // runs successfully
+      if (!dayString.empty())
+      {
+        // Erase the space
+        dayString.erase(dayString.length() - 1);
+        try
+        {
+          std::stoi(dayString);
+        }
+        catch (const std::out_of_range &)
+        {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
     /// \brief Split a std::chrono::steady_clock::duration to a string
     /// \param[in] _timeString The string to convert in general format
     /// \param[out] numberDays number of days in the string

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -639,6 +639,7 @@ TEST(HelpersTest, stringToDuration)
   std::chrono::steady_clock::duration duration =
     std::chrono::steady_clock::duration::zero();
 
+  EXPECT_TRUE(math::isTimeString(time));
   EXPECT_EQ(resultTime, duration);
 
   time = "10 0";
@@ -646,6 +647,7 @@ TEST(HelpersTest, stringToDuration)
   duration = std::chrono::steady_clock::duration::zero();
   duration += std::chrono::hours(10 * 24);
 
+  EXPECT_TRUE(math::isTimeString(time));
   EXPECT_EQ(resultTime, duration);
 
   time = "7";
@@ -653,6 +655,7 @@ TEST(HelpersTest, stringToDuration)
   duration = std::chrono::steady_clock::duration::zero();
   duration += std::chrono::seconds(7);
 
+  EXPECT_TRUE(math::isTimeString(time));
   EXPECT_EQ(resultTime, duration);
 
   time = "7:10";
@@ -661,6 +664,7 @@ TEST(HelpersTest, stringToDuration)
   duration += std::chrono::minutes(7);
   duration += std::chrono::seconds(10);
 
+  EXPECT_TRUE(math::isTimeString(time));
   EXPECT_EQ(resultTime, duration);
 
   time = "17:10";
@@ -669,6 +673,7 @@ TEST(HelpersTest, stringToDuration)
   duration += std::chrono::minutes(17);
   duration += std::chrono::seconds(10);
 
+  EXPECT_TRUE(math::isTimeString(time));
   EXPECT_EQ(resultTime, duration);
 
   time = "7:10.4";
@@ -678,6 +683,7 @@ TEST(HelpersTest, stringToDuration)
   duration += std::chrono::seconds(10);
   duration += std::chrono::milliseconds(400);
 
+  EXPECT_TRUE(math::isTimeString(time));
   EXPECT_EQ(resultTime, duration);
 
   time = "7:10.45";
@@ -687,6 +693,7 @@ TEST(HelpersTest, stringToDuration)
   duration += std::chrono::seconds(10);
   duration += std::chrono::milliseconds(450);
 
+  EXPECT_TRUE(math::isTimeString(time));
   EXPECT_EQ(resultTime, duration);
 
   time = "7:10.456";
@@ -696,6 +703,7 @@ TEST(HelpersTest, stringToDuration)
   duration += std::chrono::seconds(10);
   duration += std::chrono::milliseconds(456);
 
+  EXPECT_TRUE(math::isTimeString(time));
   EXPECT_EQ(resultTime, duration);
 
   time = "2 23:18:25.902";
@@ -707,6 +715,7 @@ TEST(HelpersTest, stringToDuration)
   duration += std::chrono::seconds(25);
   duration += std::chrono::milliseconds(902);
 
+  EXPECT_TRUE(math::isTimeString(time));
   EXPECT_EQ(resultTime, duration);
 
   time = ".9";
@@ -714,41 +723,49 @@ TEST(HelpersTest, stringToDuration)
   duration = std::chrono::steady_clock::duration::zero();
   duration += std::chrono::milliseconds(900);
 
+  EXPECT_TRUE(math::isTimeString(time));
   EXPECT_EQ(resultTime, duration);
 
   time = "bad time";
   resultTime = math::stringToDuration(time);
 
+  EXPECT_FALSE(math::isTimeString(time));
   EXPECT_EQ(resultTime, std::chrono::steady_clock::duration::zero());
 
   time = "";
   resultTime = math::stringToDuration(time);
 
+  EXPECT_TRUE(math::isTimeString(time));
   EXPECT_EQ(resultTime, std::chrono::steady_clock::duration::zero());
 
   time = "60";
   resultTime = math::stringToDuration(time);
 
+  EXPECT_FALSE(math::isTimeString(time));
   EXPECT_EQ(resultTime, std::chrono::steady_clock::duration::zero());
 
   time = "60:12";
   resultTime = math::stringToDuration(time);
 
+  EXPECT_FALSE(math::isTimeString(time));
   EXPECT_EQ(resultTime, std::chrono::steady_clock::duration::zero());
 
   time = "12:12.9999";
   resultTime = math::stringToDuration(time);
 
+  EXPECT_FALSE(math::isTimeString(time));
   EXPECT_EQ(resultTime, std::chrono::steady_clock::duration::zero());
 
   time = "25:12:12.99";
   resultTime = math::stringToDuration(time);
 
+  EXPECT_FALSE(math::isTimeString(time));
   EXPECT_EQ(resultTime, std::chrono::steady_clock::duration::zero());
 
   time = "999999999999999 5:12:12.5";
   resultTime = math::stringToDuration(time);
 
+  EXPECT_FALSE(math::isTimeString(time));
   EXPECT_EQ(resultTime, std::chrono::steady_clock::duration::zero());
 }
 


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

This adds a helper function that checks if a string is a represents a time.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.