### PR TITLE
Fix unsafe globals in Interval and Region3

### DIFF
--- a/include/ignition/math/Interval.hh
+++ b/include/ignition/math/Interval.hh
@@ -51,11 +51,14 @@ namespace ignition
 
       /// \brief Constructor
       /// \param[in] _leftValue leftmost interval value
-      /// \param[in] _leftClosed whether the interval is left-closed or not
+      /// \param[in] _leftClosed whether the interval is
+      ///   left-closed or not
       /// \param[in] _rightValue rightmost interval value
-      /// \param[in] _rightClosed whether the interval is right-closed or not
-      public: Interval(T _leftValue, bool _leftClosed,
-                       T _rightValue, bool _rightClosed)
+      /// \param[in] _rightClosed whether the interval
+      ///   is right-closed or not
+      public: constexpr Interval(
+          T _leftValue, bool _leftClosed,
+          T _rightValue, bool _rightClosed)
       : leftValue(std::move(_leftValue)),
         rightValue(std::move(_rightValue)),
         leftClosed(_leftClosed),
@@ -67,7 +70,8 @@ namespace ignition
       /// \param[in] _leftValue leftmost interval value
       /// \param[in] _rightValue rightmost interval value
       /// \return the open interval
-      public: static Interval<T> Open(T _leftValue, T _rightValue)
+      public: static constexpr Interval<T>
+      Open(T _leftValue, T _rightValue)
       {
         return Interval<T>(
           std::move(_leftValue), false,
@@ -78,7 +82,8 @@ namespace ignition
       /// \param[in] _leftValue leftmost interval value
       /// \param[in] _rightValue rightmost interval value
       /// \return the left-closed interval
-      public: static Interval<T> LeftClosed(T _leftValue, T _rightValue)
+      public: static constexpr Interval<T>
+      LeftClosed(T _leftValue, T _rightValue)
       {
         return Interval<T>(
           std::move(_leftValue), true,
@@ -89,7 +94,8 @@ namespace ignition
       /// \param[in] _leftValue leftmost interval value
       /// \param[in] _rightValue rightmost interval value
       /// \return the left-closed interval
-      public: static Interval<T> RightClosed(T _leftValue, T _rightValue)
+      public: static constexpr Interval<T>
+      RightClosed(T _leftValue, T _rightValue)
       {
         return Interval<T>(
           std::move(_leftValue), false,
@@ -100,7 +106,8 @@ namespace ignition
       /// \param[in] _leftValue leftmost interval value
       /// \param[in] _rightValue rightmost interval value
       /// \return the closed interval
-      public: static Interval<T> Closed(T _leftValue, T _rightValue)
+      public: static constexpr Interval<T>
+      Closed(T _leftValue, T _rightValue)
       {
         return Interval<T>{
           std::move(_leftValue), true,
@@ -276,7 +283,7 @@ namespace ignition
 
     namespace detail {
        template<typename T>
-       const Interval<T> gUnboundedInterval =
+       constexpr Interval<T> gUnboundedInterval =
            Interval<T>::Open(-std::numeric_limits<T>::infinity(),
                              std::numeric_limits<T>::infinity());
     }  // namespace detail

--- a/include/ignition/math/Region3.hh
+++ b/include/ignition/math/Region3.hh
@@ -60,7 +60,8 @@ namespace ignition
       /// \param[in] _ix x-axis interval
       /// \param[in] _iy y-axis interval
       /// \param[in] _iz z-axis interval
-      public: Region3(Interval<T> _ix, Interval<T> _iy, Interval<T> _iz)
+      public: constexpr Region3(
+          Interval<T> _ix, Interval<T> _iy, Interval<T> _iz)
       : ix(std::move(_ix)), iy(std::move(_iy)), iz(std::move(_iz))
       {
       }
@@ -74,7 +75,7 @@ namespace ignition
       /// \param[in] _zRight righmost z-axis interval value
       /// \return the (`_xLeft`, `_xRight`) ✕ (`_yLeft`, `_yRight`)
       ///  ✕ (`_zLeft`, `_zRight`) open region
-      public: static Region3<T> Open(
+      public: static constexpr Region3<T> Open(
           T _xLeft, T _yLeft, T _zLeft,
           T _xRight, T _yRight, T _zRight)
       {
@@ -92,7 +93,7 @@ namespace ignition
       /// \param[in] _zRight righmost z-axis interval value
       /// \return the [`_xLeft`, `_xRight`] ✕ [`_yLeft`, `_yRight`]
       ///  ✕ [`_zLeft`, `_zRight`] closed region
-      public: static Region3<T> Closed(
+      public: static constexpr Region3<T> Closed(
           T _xLeft, T _yLeft, T _zLeft,
           T _xRight, T _yRight, T _zRight)
       {
@@ -188,7 +189,7 @@ namespace ignition
 
     namespace detail {
        template<typename T>
-       const Region3<T> gUnboundedRegion3(
+       constexpr Region3<T> gUnboundedRegion3(
            Interval<T>::Open(-std::numeric_limits<T>::infinity(),
                              std::numeric_limits<T>::infinity()),
            Interval<T>::Open(-std::numeric_limits<T>::infinity(),


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Relates to #269.

## Summary
This PR fixes a potential global initialization order issue introduced in #388 and #390 by making all `Interval` and `Region3` construction forms `constexpr`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.