### PR TITLE
Fix TODO comments: enable test and remove ifdef

### DIFF
--- a/src/Helpers.cc
+++ b/src/Helpers.cc
@@ -41,17 +41,10 @@ namespace ignition
       // Accurate 64-bit integer sqrt
       //  From https://stackoverflow.com/a/18501209
       //
-      // \todo: Remove this ifdef and use the "0x1p-20" version when c++17
-      // is used. All platforms should then support the "p" literal.
-      //
       // Note that the of Hexadecimal floats is failing in some Linux g++
       // compilers from 6.x/7.x series. The native support for C++ is defined
       // in C++17 See https://bugzilla.redhat.com/show_bug.cgi?id=1321986
-#if (__cplusplus < 201703L)
-      uint64_t sqrt = static_cast<uint64_t>(std::sqrt(_key) -9.53674e-07);
-#else
       uint64_t sqrt = static_cast<uint64_t>(std::sqrt(_key) - 0x1p-20);
-#endif
       if (2 * sqrt < _key - sqrt * sqrt)
         sqrt++;
 

--- a/src/python_pybind11/test/PID_TEST.py
+++ b/src/python_pybind11/test/PID_TEST.py
@@ -185,12 +185,11 @@ class TestPID(unittest.TestCase):
         self.update_test(pid, 0,  1, 0, 1, 0, 0)
 
         # dt < 0, but gains still zero
-        # TODO(chapulina) Check why d_error fails in the commented test cases
         self.update_test(pid, 0,  1, -1,  1, 0, 0)
         self.update_test(pid, 0,  1, -1,  1, 0, 0)
-        # self.update_test(pid, 0, -1, -1, -1, 0, 2)
-        # self.update_test(pid, 0, -1, -1, -1, 0, 0)
-        # self.update_test(pid, 0,  1, -1,  1, 0, -2)
+        self.update_test(pid, 0, -1, -1, -1, 0, 2)
+        self.update_test(pid, 0, -1, -1, -1, 0, 0)
+        self.update_test(pid, 0,  1, -1,  1, 0, -2)
         self.update_test(pid, 0,  1, -1,  1, 0, 0)
 
         pid.reset()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes some TODO comments

## Summary

This enables some test expectations in the PID python test since we are now using pybind11, and removes an `ifdef` from Helpers.cc since we are now using C++17.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
