### PR TITLE
packages.apt: install libpython3-dev

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,6 +1,7 @@
 libeigen3-dev
 libignition-cmake3-dev
 libignition-utils2-dev
+libpython3-dev
 python3-distutils
 python3-pybind11
 ruby-dev


### PR DESCRIPTION
# 🦟 Bug fix

Fixes Ubuntu 20.04 builds on `main` that fail to find Python

## Summary

The Ubuntu 20.04 builds on `main` fail to find Python since https://github.com/ignition-tooling/release-tools/pull/709 was merged and the `libpython3-dev` was no longer installed in our Jenkins Ubuntu builds. This adds the package to our `packages.apt` file.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
