### PR TITLE
Backport #414: packages.apt install libpython3-dev

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,5 +1,6 @@
 libeigen3-dev
 libignition-cmake2-dev
+libpython3-dev
 python3-distutils
 python3-pybind11
 ruby-dev


### PR DESCRIPTION
# 🦟 Bug fix

Backport #414 to `ign-math6`

## Summary

Add `libpython3-dev` to `packages.apt`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Use **Rebase-and-merge**